### PR TITLE
홈 화면 티켓 AsyncImage를 사용한 url 이미지 로드와 url을 imageUrl로 네이밍 수정

### DIFF
--- a/core/designsystem/src/main/java/com/alreadyoccupiedseat/designsystem/component/ShowPotTicket.kt
+++ b/core/designsystem/src/main/java/com/alreadyoccupiedseat/designsystem/component/ShowPotTicket.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -31,7 +32,7 @@ import com.alreadyoccupiedseat.designsystem.typo.korean.ShowPotKoreanText_B2_Reg
 @Composable
 fun ShowPotTicket(
     modifier: Modifier = Modifier,
-    url: String,
+    imageUrl: String,
     showTime: String,
     showTimeTextColor: Color,
     showName: String,
@@ -50,18 +51,6 @@ fun ShowPotTicket(
                 onClick()
             }
     ) {
-        AsyncImage(
-            model = ImageRequest.Builder(LocalContext.current)
-                .data(url)
-                .crossfade(true)
-                .build(),
-            contentScale = ContentScale.FillBounds,
-            contentDescription = "Loaded Image",
-            modifier = Modifier
-                .width(178.5.dp)
-                .fillMaxHeight()
-                .align(Alignment.CenterEnd),
-        )
 
         Row {
             Spacer(
@@ -70,19 +59,40 @@ fun ShowPotTicket(
                     .fillMaxHeight()
                     .weight(1f)
             )
+
             Box(
                 modifier = Modifier
                     .fillMaxHeight()
                     .weight(1f)
-                    .background(
-                        brush = Brush.horizontalGradient(
-                            colors = listOf(
-                                ShowpotColor.Gray700,
-                                ShowpotColor.Gray700.copy(alpha = 0f)
-                            ),
+            ) {
+
+                AsyncImage(
+                    model = ImageRequest.Builder(LocalContext.current)
+                        .data(imageUrl)
+                        .crossfade(true)
+                        .build(),
+                    contentScale = ContentScale.Crop,
+                    contentDescription = "Loaded Image",
+                    modifier = Modifier
+                        .fillMaxHeight()
+                        .align(Alignment.Center),
+                )
+
+                Spacer(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(
+                            brush = Brush.horizontalGradient(
+                                colors = listOf(
+                                    ShowpotColor.Gray700,
+                                    ShowpotColor.Gray700.copy(alpha = 0f)
+                                ),
+                            )
                         )
-                    )
-            )
+                        .align(Alignment.Center)
+                )
+            }
+
         }
 
         Row {

--- a/core/designsystem/src/main/java/com/alreadyoccupiedseat/designsystem/preview/ComponentsPreview.kt
+++ b/core/designsystem/src/main/java/com/alreadyoccupiedseat/designsystem/preview/ComponentsPreview.kt
@@ -23,12 +23,12 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.alreadyoccupiedseat.designsystem.R
 import com.alreadyoccupiedseat.designsystem.ShowpotColor
+import com.alreadyoccupiedseat.designsystem.component.RecommendedShow
 import com.alreadyoccupiedseat.designsystem.component.ShowPotArtist
 import com.alreadyoccupiedseat.designsystem.component.ShowPotArtistAlarm
 import com.alreadyoccupiedseat.designsystem.component.ShowPotArtistDelete
 import com.alreadyoccupiedseat.designsystem.component.ShowPotArtistSubscription
 import com.alreadyoccupiedseat.designsystem.component.ShowPotButtonWithIcon
-import com.alreadyoccupiedseat.designsystem.component.RecommendedShow
 import com.alreadyoccupiedseat.designsystem.component.ShowPotGenre
 import com.alreadyoccupiedseat.designsystem.component.ShowPotMainButton
 import com.alreadyoccupiedseat.designsystem.component.ShowPotMenu
@@ -143,6 +143,44 @@ fun ComponentsPreview() {
         }
 
         item {
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+
+        item {
+            ShowPotTicket(
+                imageUrl = "https://img.hankyung.com/photo/202406/01.37069998.1.jpg",
+                showTime = "OPEN : 06.10(MON) AM 11:00",
+                showTimeTextColor = ShowpotColor.MainYellow,
+                showName = "Nothing But Thieves But Thieves ",
+                showLocation = "KBS 아레나홀",
+                onClick = {
+                    Log.d("ShowPotTicket", "onClick")
+                }
+            )
+        }
+
+        item {
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+
+        item {
+            ShowPotTicket(
+                imageUrl = "https://img.hankyung.com/photo/202406/01.37069998.1.jpg",
+                showTime = "OPEN : 06.10(MON) AM 11:00",
+                showTimeTextColor = ShowpotColor.MainBlue,
+                showName = "Nothing But Thieves But Thieves ",
+                showLocation = "KBS 아레나홀",
+                onClick = {
+                    Log.d("ShowPotTicket", "onClick")
+                }
+            )
+        }
+
+        item {
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+
+        item {
             RecommendedShow(
                 image = painterResource(id = R.drawable.img_default_poster_01),
                 text = "Nothing But Thieves hey.d.",
@@ -151,6 +189,10 @@ fun ComponentsPreview() {
                     Log.d("ShowPotConcertCards", "onClick")
                 }
             )
+        }
+
+        item {
+            Spacer(modifier = Modifier.height(16.dp))
         }
 
         item {


### PR DESCRIPTION
## 🤘 작업 내용
- 홈 화면 티켓 비율(가중치) 적용 이후 배치
- AsyncImage 적용 url을 통한 이미지 로드
- 파라미터 url -> imageUrl 네이밍 수정 

## 💻 동작 화면
<img width="359" alt="image" src="https://github.com/user-attachments/assets/7fe36c3f-51cc-4b23-b48a-7d0eaf610753">

