### PR TITLE
최근 검색어 개수 7개로 제한

### DIFF
--- a/core/datastore/src/main/java/com/alreadyoccupiedseat/datastore/SearchHistoryDataStore.kt
+++ b/core/datastore/src/main/java/com/alreadyoccupiedseat/datastore/SearchHistoryDataStore.kt
@@ -23,6 +23,7 @@ class SearchHistoryDataStore @Inject constructor(@ApplicationContext private val
             .reversed()
             .distinct()
             .reversed()
+            .takeLast(7)
             .toConvertedString()
         updateSearchedKeywordKey(newHistories)
         return newHistories.toConvertedList()


### PR DESCRIPTION
## 🤘 작업 내용
- 최근 검색어 개수 7개로 제한

## 📋 변경된 내용
- SearchHistoryDataStore에서 최근 검색어 저장될 때 7개로 최대 개수 제한

