### PR TITLE
쇼팟 기본 스낵바 및 체크 아이콘 고정 스낵바 구현

### DIFF
--- a/core/designsystem/src/main/java/com/alreadyoccupiedseat/designsystem/component/snackbar/CheckIconSnackbar.kt
+++ b/core/designsystem/src/main/java/com/alreadyoccupiedseat/designsystem/component/snackbar/CheckIconSnackbar.kt
@@ -1,0 +1,21 @@
+package com.alreadyoccupiedseat.designsystem.component.snackbar
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.painterResource
+import com.alreadyoccupiedseat.designsystem.R
+
+@Composable
+fun CheckIconSnackbar(
+    mainText: String,
+    actionText: String,
+    onIconClicked: () -> Unit,
+    onActionTextClicked: () -> Unit
+) {
+    ShowPotSnackbar(
+        iconPainter = painterResource(id = R.drawable.ic_check_36),
+        mainText = mainText,
+        actionText = actionText,
+        onIconClicked = onIconClicked,
+        onActionTextClicked = onActionTextClicked
+    )
+}

--- a/core/designsystem/src/main/java/com/alreadyoccupiedseat/designsystem/component/snackbar/ShowPotSnackbar.kt
+++ b/core/designsystem/src/main/java/com/alreadyoccupiedseat/designsystem/component/snackbar/ShowPotSnackbar.kt
@@ -1,0 +1,65 @@
+package com.alreadyoccupiedseat.designsystem.component.snackbar
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.unit.dp
+import com.alreadyoccupiedseat.designsystem.ShowpotColor
+import com.alreadyoccupiedseat.designsystem.typo.korean.ShowPotKoreanText_B1_SemiBold
+
+@Composable
+fun ShowPotSnackbar(
+    iconPainter: Painter,
+    mainText: String,
+    actionText: String,
+    onIconClicked: () -> Unit,
+    onActionTextClicked: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .padding(horizontal = 30.dp, vertical = 42.dp)
+            .fillMaxWidth()
+            .height(46.dp)
+            .background(ShowpotColor.Gray500),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+
+        Icon(
+            modifier = Modifier
+                .padding(start = 7.dp, end = 3.dp)
+                .clickable {
+                    onIconClicked()
+                },
+            painter = iconPainter,
+            tint = ShowpotColor.Gray200,
+            contentDescription = "snackbar icon"
+        )
+
+        ShowPotKoreanText_B1_SemiBold(
+            modifier = Modifier.weight(1f),
+            text = mainText,
+            color = Color.White
+        )
+
+        ShowPotKoreanText_B1_SemiBold(
+            modifier = Modifier
+                .padding(
+                    start = 16.dp, end = 13.dp
+                )
+                .clickable {
+                    onActionTextClicked()
+                },
+            text = actionText,
+            color = ShowpotColor.MainRed
+        )
+    }
+}

--- a/feature/subscription-artist/src/main/java/com/alreadyoccupiedseat/subscription_artist/SubscriptionArtistScreen.kt
+++ b/feature/subscription-artist/src/main/java/com/alreadyoccupiedseat/subscription_artist/SubscriptionArtistScreen.kt
@@ -14,8 +14,12 @@ import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -27,8 +31,10 @@ import androidx.navigation.NavController
 import com.alreadyoccupiedseat.designsystem.ShowpotColor
 import com.alreadyoccupiedseat.designsystem.component.ShowPotArtistSubscription
 import com.alreadyoccupiedseat.designsystem.component.ShowPotMainButton
+import com.alreadyoccupiedseat.designsystem.component.snackbar.CheckIconSnackbar
 import com.alreadyoccupiedseat.designsystem.typo.korean.ShowPotKoreanText_H1
 import com.alreadyoccupiedseat.designsystem.typo.korean.ShowPotKoreanText_H2
+import kotlinx.coroutines.launch
 
 @Composable
 fun SubscriptionArtistScreen(
@@ -58,10 +64,29 @@ fun SubscriptionArtistScreenContent(
     onBackClicked: () -> Unit,
     onSubscribeButtonClicked: () -> Unit = {},
 ) {
+
+    val scope = rememberCoroutineScope()
+    val snackbarHostState = remember { SnackbarHostState() }
+
     Scaffold(
         modifier = Modifier
             .fillMaxSize(),
         containerColor = ShowpotColor.Gray700,
+        snackbarHost = {
+            SnackbarHost(
+                hostState = snackbarHostState,
+            ) { snackbarData ->
+                CheckIconSnackbar(
+                    mainText = snackbarData.visuals.message,
+                    actionText = "보러가기",
+                    onIconClicked = {
+                        // onIconClicked()
+                    },
+                ) {
+                    // onActionClicked()
+                }
+            }
+        },
         // TODO: To be a component
         topBar = {
             Row(
@@ -118,7 +143,8 @@ fun SubscriptionArtistScreenContent(
                     items(count = 21) {
                         ShowPotArtistSubscription(
                             text = "High Flying Birds",
-                            icon = painterResource(id = com.alreadyoccupiedseat.designsystem.R.drawable.img_artist_default),)
+                            icon = painterResource(id = com.alreadyoccupiedseat.designsystem.R.drawable.img_artist_default),
+                        )
                     }
 
                 }
@@ -136,7 +162,10 @@ fun SubscriptionArtistScreenContent(
                             .fillMaxWidth(),
                         text = stringResource(R.string.subscribe)
                     ) {
-                        onSubscribeButtonClicked()
+                        scope.launch {
+                            onSubscribeButtonClicked()
+                            snackbarHostState.showSnackbar("구독 설정이 완료되었습니다")
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## 🤘 작업 내용
- 쇼팟 기본 스낵바 체크 아이콘 고정 스낵바 구현

## 📋 변경된 내용
- X

## 💻 동작 화면
![snack](https://github.com/user-attachments/assets/95c5ce6d-6d2b-4148-85af-11a0e138c2c0)


## 📌 비고
- 스낵바 사용은 Scaffold에서 제가 아티스트 구독 화면에 적용한 것 처럼 하시면 됩니다.
