### PR TITLE
카카오 로그인 기능 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,9 +1,14 @@
+import java.util.Properties
+
 plugins {
     alias(libs.plugins.showpot.application)
     alias(libs.plugins.showpot.firebase)
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.showpot.hilt)
 }
+
+val properties = Properties()
+properties.load(project.rootProject.file("local.properties").inputStream())
 
 android {
     namespace = "com.alreadyoccupiedseat.showpot"
@@ -13,6 +18,15 @@ android {
         targetSdk = 34
         versionCode = 1
         versionName = "1.0"
+
+        // for using it on the .kt files
+        buildConfigField(
+            "String",
+            "kakaoNativeAppKeyString",
+            properties.getProperty("kakao_sdk_native_key_string")
+        )
+        // for using it on the manifest
+        manifestPlaceholders["kakaoNativeAppKey"] = properties["kakao_sdk_native_key"] as Any
 
         vectorDrawables {
             useSupportLibrary = true
@@ -30,6 +44,7 @@ android {
     }
     buildFeatures {
         compose = true
+        buildConfig = true
     }
     packaging {
         resources {
@@ -37,6 +52,7 @@ android {
         }
     }
 }
+
 
 dependencies {
 
@@ -75,5 +91,6 @@ dependencies {
 
     implementation(libs.coil.kt.compose)
 
+    implementation(libs.kakao)
 
 }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,11 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+-keep class com.kakao.sdk.**.model.* { <fields>; }
+-keep class * extends com.google.gson.TypeAdapter
+
+# https://github.com/square/okhttp/pull/6792
+-dontwarn org.bouncycastle.jsse.**
+-dontwarn org.conscrypt.*
+-dontwarn org.openjsse.**

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.alreadyoccupiedseat.showpot"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET" />
     <application
         android:name=".ShowPotApplication"
         android:allowBackup="true"
@@ -13,6 +15,10 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.ShowPot"
         tools:targetApi="31">
+
+        <meta-data
+            android:name="com.kakao.sdk.AppKey"
+            android:value="kakao${kakaoNativeAppKey}"/>
         <activity
             android:name="com.alreadyoccupiedseat.showpot.MainActivity"
             android:exported="true">
@@ -20,6 +26,19 @@
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+
+        <activity
+            android:name="com.kakao.sdk.auth.AuthCodeHandlerActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:host="oauth"
+                    android:scheme="kakao${kakaoNativeAppKey}" />
             </intent-filter>
         </activity>
     </application>

--- a/app/src/main/java/com/alreadyoccupiedseat/showpot/Screen.kt
+++ b/app/src/main/java/com/alreadyoccupiedseat/showpot/Screen.kt
@@ -16,6 +16,11 @@ sealed class Screen(
     selectedIcon = selectedIcon,
 ) {
 
+    data object Login: Screen(
+        route = "login",
+        title = "로그인"
+    )
+
     data object Home : Screen(
         route = "home",
         title = "홈",

--- a/app/src/main/java/com/alreadyoccupiedseat/showpot/ShowPotApplication.kt
+++ b/app/src/main/java/com/alreadyoccupiedseat/showpot/ShowPotApplication.kt
@@ -1,9 +1,14 @@
 package com.alreadyoccupiedseat.showpot
 
 import android.app.Application
+import com.kakao.sdk.common.KakaoSdk
 import dagger.hilt.android.HiltAndroidApp
 
 @HiltAndroidApp
 class ShowPotApplication: Application() {
 
+    override fun onCreate() {
+        super.onCreate()
+        KakaoSdk.init(this, BuildConfig.kakaoNativeAppKeyString)
+    }
 }

--- a/app/src/main/java/com/alreadyoccupiedseat/showpot/ui/AppScreen.kt
+++ b/app/src/main/java/com/alreadyoccupiedseat/showpot/ui/AppScreen.kt
@@ -16,6 +16,7 @@ import com.alreadyoccupiedseat.core.extension.EMPTY
 import com.alreadyoccupiedseat.designsystem.ShowpotColor
 import com.alreadyoccupiedseat.designsystem.component.ShowPotBottomNavigation
 import com.alreadyoccupiedseat.home.HomeScreen
+import com.alreadyoccupiedseat.login.LoginScreen
 import com.alreadyoccupiedseat.mypage.MyPageScreen
 import com.alreadyoccupiedseat.notification.NotificationScreen
 import com.alreadyoccupiedseat.search.SearchScreen
@@ -72,11 +73,15 @@ fun AppScreenContent() {
             androidx.compose.ui.Modifier.padding(innerPadding),
         ) {
 
+            composable(Screen.Login.route) {
+                LoginScreen(navController)
+            }
+
             composable(Screen.Home.route) {
                 HomeScreen(
                     navController = navController,
                     onSearchBarClicked = {
-                        navController.navigate(Screen.Search.route)
+                        navController.navigate(Screen.Login.route)
                     },
                     onSubscriptionGenreClicked = {
                         navController.navigate(Screen.SubscriptionGenre.route)

--- a/app/src/main/java/com/alreadyoccupiedseat/showpot/ui/AppScreen.kt
+++ b/app/src/main/java/com/alreadyoccupiedseat/showpot/ui/AppScreen.kt
@@ -81,7 +81,7 @@ fun AppScreenContent() {
                 HomeScreen(
                     navController = navController,
                     onSearchBarClicked = {
-                        navController.navigate(Screen.Login.route)
+                        navController.navigate(Screen.Search.route)
                     },
                     onSubscriptionGenreClicked = {
                         navController.navigate(Screen.SubscriptionGenre.route)

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -53,4 +53,6 @@ dependencies {
     implementation(libs.retrofit)
     implementation(libs.okhttp)
     implementation(libs.okhttp.logging)
+
+    implementation(libs.kakao)
 }

--- a/core/data/src/main/java/com/alreadyoccupiedseat/data/login/LoginDataSource.kt
+++ b/core/data/src/main/java/com/alreadyoccupiedseat/data/login/LoginDataSource.kt
@@ -2,6 +2,6 @@ package com.alreadyoccupiedseat.data.login
 
 interface LoginDataSource {
 
-    fun login()
+    suspend fun login(): String
 
 }

--- a/core/data/src/main/java/com/alreadyoccupiedseat/data/login/LoginDataSource.kt
+++ b/core/data/src/main/java/com/alreadyoccupiedseat/data/login/LoginDataSource.kt
@@ -1,0 +1,7 @@
+package com.alreadyoccupiedseat.data.login
+
+interface LoginDataSource {
+
+    fun login()
+
+}

--- a/core/data/src/main/java/com/alreadyoccupiedseat/data/login/LoginModule.kt
+++ b/core/data/src/main/java/com/alreadyoccupiedseat/data/login/LoginModule.kt
@@ -1,0 +1,25 @@
+package com.alreadyoccupiedseat.data.login
+
+import com.alreadyoccupiedseat.data.login.kakao.KakaoLoginDataSourceImpl
+import com.alreadyoccupiedseat.data.login.kakao.KakaoLoginRepositoryImpl
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class LoginModule {
+
+    @Singleton
+    @Binds
+    @KakaoLoginDataSource
+    abstract fun bindKakaoLoginDataSource(kakaoLoginDataSourceImpl: KakaoLoginDataSourceImpl): LoginDataSource
+
+    @Singleton
+    @Binds
+    @KakaoLoginRepository
+    abstract fun bindKakaoLoginRepository(kakaoLoginRepositoryImpl: KakaoLoginRepositoryImpl): LoginRepository
+
+}

--- a/core/data/src/main/java/com/alreadyoccupiedseat/data/login/LoginQulifier.kt
+++ b/core/data/src/main/java/com/alreadyoccupiedseat/data/login/LoginQulifier.kt
@@ -1,0 +1,11 @@
+package com.alreadyoccupiedseat.data.login
+
+import javax.inject.Qualifier
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class KakaoLoginRepository
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class KakaoLoginDataSource

--- a/core/data/src/main/java/com/alreadyoccupiedseat/data/login/LoginRepository.kt
+++ b/core/data/src/main/java/com/alreadyoccupiedseat/data/login/LoginRepository.kt
@@ -1,0 +1,7 @@
+package com.alreadyoccupiedseat.data.login
+
+interface LoginRepository {
+
+    fun login()
+
+}

--- a/core/data/src/main/java/com/alreadyoccupiedseat/data/login/LoginRepository.kt
+++ b/core/data/src/main/java/com/alreadyoccupiedseat/data/login/LoginRepository.kt
@@ -2,6 +2,6 @@ package com.alreadyoccupiedseat.data.login
 
 interface LoginRepository {
 
-    fun login()
+    suspend fun login(): String
 
 }

--- a/core/data/src/main/java/com/alreadyoccupiedseat/data/login/kakao/KakaoLoginDataSourceImpl.kt
+++ b/core/data/src/main/java/com/alreadyoccupiedseat/data/login/kakao/KakaoLoginDataSourceImpl.kt
@@ -1,60 +1,42 @@
 package com.alreadyoccupiedseat.data.login.kakao
 
-import android.content.ContentValues
 import android.content.Context
-import android.util.Log
 import com.alreadyoccupiedseat.data.login.KakaoLoginDataSource
 import com.alreadyoccupiedseat.data.login.LoginDataSource
 import com.kakao.sdk.auth.model.OAuthToken
-import com.kakao.sdk.common.model.ClientError
-import com.kakao.sdk.common.model.ClientErrorCause
 import com.kakao.sdk.user.UserApiClient
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.suspendCancellableCoroutine
 import javax.inject.Inject
+import kotlin.coroutines.resumeWithException
 
 @KakaoLoginDataSource
 class KakaoLoginDataSourceImpl @Inject constructor(
     @ApplicationContext private val context: Context
 ) : LoginDataSource {
-    override fun login() {
-
-        val mCallback: (OAuthToken?, Throwable?) -> Unit = { token, error ->
-            if (error != null) {
-                Log.e(ContentValues.TAG, "로그인 실패 $error")
-            } else if (token != null) {
-                Log.e(ContentValues.TAG, "로그인 성공 ${token.accessToken}")
-            }
-        }
-
-        // 카카오톡 설치 확인
-        if (UserApiClient.instance.isKakaoTalkLoginAvailable(context)) {
-            // 카카오톡 로그인
-            UserApiClient.instance.loginWithKakaoTalk(context) { token, error ->
-                // 로그인 실패 부분
+    @OptIn(ExperimentalCoroutinesApi::class)
+    override suspend fun login(): String {
+        return suspendCancellableCoroutine { continuation ->
+            // 카카오 로그인 콜백
+            val callback: (OAuthToken?, Throwable?) -> Unit = { token, error ->
                 if (error != null) {
-                    Log.e(ContentValues.TAG, "로그인 실패 $error")
-                    // 사용자가 취소
-                    if (error is ClientError && error.reason == ClientErrorCause.Cancelled) {
-                        return@loginWithKakaoTalk
+                    continuation.resumeWithException(Exception("카카오 소셜 로그인 실패"))
+                } else if (token != null) {
+                    continuation.resume(token.accessToken) {
+                        // onCancellation
                     }
-                    // 다른 오류
-                    else {
-                        UserApiClient.instance.loginWithKakaoAccount(
-                            context,
-                            callback = mCallback
-                        ) // 카카오 이메일 로그인
-                    }
-                }
-                // 로그인 성공 부분
-                else if (token != null) {
-                    Log.e(ContentValues.TAG, "로그인 성공 ${token.accessToken}")
+                } else {
+                    continuation.resumeWithException(Exception("카카오 소셜 로그인 실패"))
                 }
             }
-        } else {
-            UserApiClient.instance.loginWithKakaoAccount(
-                context,
-                callback = mCallback
-            ) // 카카오 이메일 로그인
+
+            // 카카오 로그인 시작
+            if (UserApiClient.instance.isKakaoTalkLoginAvailable(context)) {
+                UserApiClient.instance.loginWithKakaoTalk(context, callback = callback)
+            } else {
+                UserApiClient.instance.loginWithKakaoAccount(context, callback = callback)
+            }
         }
     }
 }

--- a/core/data/src/main/java/com/alreadyoccupiedseat/data/login/kakao/KakaoLoginDataSourceImpl.kt
+++ b/core/data/src/main/java/com/alreadyoccupiedseat/data/login/kakao/KakaoLoginDataSourceImpl.kt
@@ -1,0 +1,60 @@
+package com.alreadyoccupiedseat.data.login.kakao
+
+import android.content.ContentValues
+import android.content.Context
+import android.util.Log
+import com.alreadyoccupiedseat.data.login.KakaoLoginDataSource
+import com.alreadyoccupiedseat.data.login.LoginDataSource
+import com.kakao.sdk.auth.model.OAuthToken
+import com.kakao.sdk.common.model.ClientError
+import com.kakao.sdk.common.model.ClientErrorCause
+import com.kakao.sdk.user.UserApiClient
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+
+@KakaoLoginDataSource
+class KakaoLoginDataSourceImpl @Inject constructor(
+    @ApplicationContext private val context: Context
+) : LoginDataSource {
+    override fun login() {
+
+        val mCallback: (OAuthToken?, Throwable?) -> Unit = { token, error ->
+            if (error != null) {
+                Log.e(ContentValues.TAG, "로그인 실패 $error")
+            } else if (token != null) {
+                Log.e(ContentValues.TAG, "로그인 성공 ${token.accessToken}")
+            }
+        }
+
+        // 카카오톡 설치 확인
+        if (UserApiClient.instance.isKakaoTalkLoginAvailable(context)) {
+            // 카카오톡 로그인
+            UserApiClient.instance.loginWithKakaoTalk(context) { token, error ->
+                // 로그인 실패 부분
+                if (error != null) {
+                    Log.e(ContentValues.TAG, "로그인 실패 $error")
+                    // 사용자가 취소
+                    if (error is ClientError && error.reason == ClientErrorCause.Cancelled) {
+                        return@loginWithKakaoTalk
+                    }
+                    // 다른 오류
+                    else {
+                        UserApiClient.instance.loginWithKakaoAccount(
+                            context,
+                            callback = mCallback
+                        ) // 카카오 이메일 로그인
+                    }
+                }
+                // 로그인 성공 부분
+                else if (token != null) {
+                    Log.e(ContentValues.TAG, "로그인 성공 ${token.accessToken}")
+                }
+            }
+        } else {
+            UserApiClient.instance.loginWithKakaoAccount(
+                context,
+                callback = mCallback
+            ) // 카카오 이메일 로그인
+        }
+    }
+}

--- a/core/data/src/main/java/com/alreadyoccupiedseat/data/login/kakao/KakaoLoginRepositoryImpl.kt
+++ b/core/data/src/main/java/com/alreadyoccupiedseat/data/login/kakao/KakaoLoginRepositoryImpl.kt
@@ -1,0 +1,16 @@
+package com.alreadyoccupiedseat.data.login.kakao
+
+import com.alreadyoccupiedseat.data.login.KakaoLoginDataSource
+import com.alreadyoccupiedseat.data.login.KakaoLoginRepository
+import com.alreadyoccupiedseat.data.login.LoginDataSource
+import com.alreadyoccupiedseat.data.login.LoginRepository
+import javax.inject.Inject
+
+@KakaoLoginRepository
+class KakaoLoginRepositoryImpl @Inject constructor(
+    @KakaoLoginDataSource private val kaKaoLoginDataSource: LoginDataSource
+) : LoginRepository{
+    override fun login() {
+        kaKaoLoginDataSource.login()
+    }
+}

--- a/core/data/src/main/java/com/alreadyoccupiedseat/data/login/kakao/KakaoLoginRepositoryImpl.kt
+++ b/core/data/src/main/java/com/alreadyoccupiedseat/data/login/kakao/KakaoLoginRepositoryImpl.kt
@@ -10,7 +10,7 @@ import javax.inject.Inject
 class KakaoLoginRepositoryImpl @Inject constructor(
     @KakaoLoginDataSource private val kaKaoLoginDataSource: LoginDataSource
 ) : LoginRepository{
-    override fun login() {
-        kaKaoLoginDataSource.login()
+    override suspend fun login(): String {
+        return kaKaoLoginDataSource.login()
     }
 }

--- a/feature/login/build.gradle.kts
+++ b/feature/login/build.gradle.kts
@@ -37,6 +37,7 @@ android {
 dependencies {
 
     implementation(project(":core:designsystem"))
+    implementation(project(":core:data"))
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)

--- a/feature/login/src/main/java/com/alreadyoccupiedseat/login/LoginScreen.kt
+++ b/feature/login/src/main/java/com/alreadyoccupiedseat/login/LoginScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.ButtonColors
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
@@ -23,7 +22,8 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import com.alreadyoccupiedseat.designsystem.R
 import com.alreadyoccupiedseat.designsystem.ShowpotColor
@@ -32,23 +32,40 @@ import com.alreadyoccupiedseat.designsystem.component.ShowPotTopBar
 import com.alreadyoccupiedseat.designsystem.typo.korean.ShowPotKoreanText_H2
 
 @Composable
-fun LoginScreen(modifier: Modifier = Modifier) {
-    val viewModel = viewModel<LoginViewModel>()
+fun LoginScreen(
+    navController: NavController
+) {
+    val viewModel = hiltViewModel<LoginViewModel>()
     val event = viewModel.event.collectAsState()
 
+    when (event.value) {
+        is LoginScreenEvent.Idle -> {
+
+        }
+
+        is LoginScreenEvent.LoginRequested -> {
+
+        }
+
+        is LoginScreenEvent.LoginCompleted -> {
+
+        }
+
+        is LoginScreenEvent.LoginError -> {
+
+        }
+    }
+
     LoginContent(
-        event = event.value,
-        onLoginCompleted = viewModel::loginCompleted,
+        onKakaoLoginClicked = viewModel::tryKakaoLogin
     )
 
 }
 
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun LoginContent(
-    event: LoginScreenEvent,
-    onLoginCompleted: () -> Unit,
+    onKakaoLoginClicked: () -> Unit,
 ) {
     val navController = rememberNavController()
 
@@ -117,7 +134,7 @@ fun LoginContent(
                         disabledContentColor = ShowpotColor.Gray400,
                     ),
                     onClick = {
-                        /* 카카오 로그인 */
+                        onKakaoLoginClicked()
                     }
                 )
 
@@ -144,24 +161,6 @@ fun LoginContent(
             }
         }
     )
-
-    when (event) {
-        is LoginScreenEvent.Idle -> {
-
-        }
-
-        is LoginScreenEvent.LoginRequested -> {
-
-        }
-
-        is LoginScreenEvent.LoginCompleted -> {
-            onLoginCompleted()
-        }
-
-        is LoginScreenEvent.LoginError -> {
-
-        }
-    }
 
 }
 

--- a/feature/login/src/main/java/com/alreadyoccupiedseat/login/LoginViewModel.kt
+++ b/feature/login/src/main/java/com/alreadyoccupiedseat/login/LoginViewModel.kt
@@ -3,7 +3,7 @@ package com.alreadyoccupiedseat.login
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.alreadyoccupiedseat.data.login.KakaoLoginRepository
-import com.alreadyoccupiedseat.data.login.LoginDataSource
+import com.alreadyoccupiedseat.data.login.LoginRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
@@ -18,7 +18,7 @@ sealed interface LoginScreenEvent {
 
 @HiltViewModel
 class LoginViewModel @Inject constructor(
-    @KakaoLoginRepository private val kakaoLoginDataSource: LoginDataSource
+    @KakaoLoginRepository private val kakaoLoginRepository: LoginRepository
 ) : ViewModel() {
 
     private var _event = MutableStateFlow<LoginScreenEvent>(LoginScreenEvent.Idle)
@@ -27,7 +27,7 @@ class LoginViewModel @Inject constructor(
     fun tryKakaoLogin() {
         viewModelScope.launch {
             _event.emit(LoginScreenEvent.LoginRequested)
-            kakaoLoginDataSource.login()
+            kakaoLoginRepository.login()
         }
     }
 

--- a/feature/login/src/main/java/com/alreadyoccupiedseat/login/LoginViewModel.kt
+++ b/feature/login/src/main/java/com/alreadyoccupiedseat/login/LoginViewModel.kt
@@ -2,6 +2,9 @@ package com.alreadyoccupiedseat.login
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.alreadyoccupiedseat.data.login.KakaoLoginRepository
+import com.alreadyoccupiedseat.data.login.LoginDataSource
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -13,15 +16,18 @@ sealed interface LoginScreenEvent {
     data class LoginError(val errorMessage: String) : LoginScreenEvent
 }
 
-class LoginViewModel @Inject constructor() : ViewModel() {
+@HiltViewModel
+class LoginViewModel @Inject constructor(
+    @KakaoLoginRepository private val kakaoLoginDataSource: LoginDataSource
+) : ViewModel() {
 
     private var _event = MutableStateFlow<LoginScreenEvent>(LoginScreenEvent.Idle)
     val event = _event
 
-    fun loginCompleted() {
+    fun tryKakaoLogin() {
         viewModelScope.launch {
-            // TODO Login
-            _event.emit(LoginScreenEvent.LoginCompleted)
+            _event.emit(LoginScreenEvent.LoginRequested)
+            kakaoLoginDataSource.login()
         }
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,6 +37,8 @@ navigationCompose = "2.7.7"
 retrofit = "2.11.0"
 okhttp = "4.10.0"
 
+kakao = "2.20.3"
+
 [libraries]
 android-tools-build-gradle = { group = "com.android.tools.build", name = "gradle", version.ref = "agp" }
 kotlin-gradle-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
@@ -111,6 +113,9 @@ firebase-messaging = { group = "com.google.firebase", name = "firebase-messaging
 ksp-gradlePlugin = { group = "com.google.devtools.ksp", name = "com.google.devtools.ksp.gradle.plugin", version.ref = "ksp" }
 room-gradlePlugin = { group = "androidx.room", name = "room-gradle-plugin", version.ref = "room" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
+
+# Kakao
+kakao = { group = "com.kakao.sdk", name = "v2-all", version.ref = "kakao" }
 
 
 [bundles]

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,6 +17,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven { url = java.net.URI("https://devrepo.kakao.com/nexus/content/groups/public/") }
     }
 }
 


### PR DESCRIPTION
## 🤘 작업 내용
- 카카오 로그인 기능 구현

## 📋 변경된 내용
- LoginViewModel에서 Event를 content 외부에서 받도록 변경
- LoginViewModel을 hilt로 가져올 수 있도록 변경

## 💻 동작 화면
<img width="438" alt="Screenshot 2024-08-12 at 4 10 09 PM" src="https://github.com/user-attachments/assets/2a302f3f-bc76-419c-9050-de88c196773e">


## 📌 비고
- 추후, 카카오 로그인 후 ShowPot 서버에 로그인 및 회원가입 기능 필요
