### PR TITLE
내 알림 변경된 메뉴들로 수정 및 연결

### DIFF
--- a/app/src/main/java/com/alreadyoccupiedseat/showpot/Screen.kt
+++ b/app/src/main/java/com/alreadyoccupiedseat/showpot/Screen.kt
@@ -77,6 +77,11 @@ sealed class Screen(
         title = "완료된 공연"
     )
 
+    data object MyFavoriteShows: Screen(
+        route = "myFavoriteShows",
+        title = "관심 공연"
+    )
+
     data object WithDraw: Screen(
         route = "withDraw",
         title = "회원 탈퇴"

--- a/app/src/main/java/com/alreadyoccupiedseat/showpot/ui/AppScreen.kt
+++ b/app/src/main/java/com/alreadyoccupiedseat/showpot/ui/AppScreen.kt
@@ -17,6 +17,7 @@ import com.alreadyoccupiedseat.designsystem.ShowpotColor
 import com.alreadyoccupiedseat.designsystem.component.ShowPotBottomNavigation
 import com.alreadyoccupiedseat.home.HomeScreen
 import com.alreadyoccupiedseat.myalarm_setting.MyAlarmSettingScreen
+import com.alreadyoccupiedseat.myfavorite_show.MyFavoriteShowScreen
 import com.alreadyoccupiedseat.myfinished_show.MyFinishedShowScreen
 import com.alreadyoccupiedseat.mypage.MyPageScreen
 import com.alreadyoccupiedseat.notification.NotificationScreen
@@ -93,9 +94,14 @@ fun AppScreenContent(isLoggedIn: Boolean) {
 
             composable(Screen.Notification.route) {
                 NotificationScreen(
-                    navController,
                     onMyAlarmSettingClicked = {
                         navController.navigate(Screen.MyAlarmSetting.route)
+                    },
+                    onMyFavoriteShowsClicked = {
+                        navController.navigate(Screen.MyFavoriteShows.route)
+                    },
+                    onMyFinishedShowClicked = {
+                        navController.navigate(Screen.MyFinishedShow.route)
                     }
                 )
             }
@@ -140,13 +146,19 @@ fun AppScreenContent(isLoggedIn: Boolean) {
             composable(Screen.Settings.route) {
                 SettingsScreen(navController)
             }
+
             composable(Screen.MyFinishedShow.route) {
                 MyFinishedShowScreen(navController)
+            }
+
+            composable(Screen.MyFavoriteShows.route) {
+                MyFavoriteShowScreen(navController)
             }
 
             composable(Screen.WithDraw.route) {
                 WithDrawScreen(navController)
             }
+
         }
     }
 }

--- a/core/designsystem/src/main/res/drawable/ic_ticket_close_24.xml
+++ b/core/designsystem/src/main/res/drawable/ic_ticket_close_24.xml
@@ -1,0 +1,16 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="18dp"
+    android:height="19dp"
+    android:viewportWidth="18"
+    android:viewportHeight="19">
+  <path
+      android:pathData="M15,2.843H17.05V6.992C15.302,7.608 14.877,9.887 16.285,11.092C16.511,11.285 16.77,11.435 17.05,11.534V15.683H10.5M7.5,2.862C7.5,2.862 3.865,2.843 1,2.843V6.992C1.28,7.09 1.539,7.24 1.765,7.433C3.173,8.639 2.748,10.917 1,11.534V15.683H4.204"
+      android:strokeWidth="1.5"
+      android:fillColor="#00000000"
+      android:strokeColor="#101012"/>
+  <path
+      android:pathData="M5.908,18.764L11.884,0.764"
+      android:strokeWidth="1.5"
+      android:fillColor="#00000000"
+      android:strokeColor="#101012"/>
+</vector>

--- a/feature/myalarm-setting/src/main/java/com/alreadyoccupiedseat/myalarm_setting/MyAlarmSettingTopBar.kt
+++ b/feature/myalarm-setting/src/main/java/com/alreadyoccupiedseat/myalarm_setting/MyAlarmSettingTopBar.kt
@@ -23,7 +23,9 @@ fun MyAlarmSettingTopBar(
             IconButton(onClick = { onBackClicked() }) {
                 Icon(
                     tint = ShowpotColor.White,
-                    modifier = Modifier.padding(1.dp),
+                    modifier = Modifier
+                        .padding(vertical = 4.dp)
+                        .padding(start = 6.dp),
                     painter = painterResource(id = R.drawable.ic_arrow_36_left),
                     contentDescription = "Back"
                 )

--- a/feature/myfavorite-show/src/main/java/com/alreadyoccupiedseat/myfavorite_show/MyFavoriteShowTopBar.kt
+++ b/feature/myfavorite-show/src/main/java/com/alreadyoccupiedseat/myfavorite_show/MyFavoriteShowTopBar.kt
@@ -23,7 +23,9 @@ fun MyFavoriteShowTopBar(
             IconButton(onClick = { onBackClicked() }) {
                 Icon(
                     tint = ShowpotColor.White,
-                    modifier = Modifier.padding(1.dp),
+                    modifier = Modifier
+                        .padding(vertical = 4.dp)
+                        .padding(start = 6.dp),
                     painter = painterResource(id = R.drawable.ic_arrow_36_left),
                     contentDescription = "Back"
                 )

--- a/feature/myfinished-show/src/main/java/com/alreadyoccupiedseat/myfinished_show/MyFinishedTopBar.kt
+++ b/feature/myfinished-show/src/main/java/com/alreadyoccupiedseat/myfinished_show/MyFinishedTopBar.kt
@@ -20,7 +20,9 @@ fun MyFinishedTopBar(modifier: Modifier = Modifier, onBackClicked: () -> Unit) {
             IconButton(onClick = { onBackClicked() }) {
                 Icon(
                     tint = ShowpotColor.White,
-                    modifier = Modifier.padding(1.dp),
+                    modifier = Modifier
+                        .padding(vertical = 4.dp)
+                        .padding(start = 6.dp),
                     painter = painterResource(id = R.drawable.ic_arrow_36_left),
                     contentDescription = "Back"
                 )

--- a/feature/notification/src/main/java/com/alreadyoccupiedseat/notification/NotificationScreen.kt
+++ b/feature/notification/src/main/java/com/alreadyoccupiedseat/notification/NotificationScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
@@ -123,8 +124,8 @@ fun NotificationScreenContent(
 
             item {
                 IconMenuWithCount(
-                    firstIcon = painterResource(id = com.alreadyoccupiedseat.designsystem.R.drawable.ic_artist_24),
-                    title = "구독한 아티스트",
+                    firstIcon = painterResource(id = com.alreadyoccupiedseat.designsystem.R.drawable.ic_heart_24),
+                    title = stringResource(com.alreadyoccupiedseat.designsystem.R.string.favorite_shows),
                     count = 3,
                 ) {
 
@@ -137,8 +138,8 @@ fun NotificationScreenContent(
 
             item {
                 IconMenuWithCount(
-                    firstIcon = painterResource(id = com.alreadyoccupiedseat.designsystem.R.drawable.ic_genre_24),
-                    title = "구독한 장르",
+                    firstIcon = painterResource(id = com.alreadyoccupiedseat.designsystem.R.drawable.ic_ticket_close_24), // Todo: Change Icon (?) -> 작아보임
+                    title = stringResource(com.alreadyoccupiedseat.designsystem.R.string.close_ticketing_shows),
                     count = 5,
                 ) {
 

--- a/feature/notification/src/main/java/com/alreadyoccupiedseat/notification/NotificationScreen.kt
+++ b/feature/notification/src/main/java/com/alreadyoccupiedseat/notification/NotificationScreen.kt
@@ -27,20 +27,29 @@ import com.alreadyoccupiedseat.designsystem.typo.korean.ShowPotKoreanText_H1
 @Preview
 @Composable
 fun PreviewNotificationScreen(modifier: Modifier = Modifier) {
-    val navController = rememberNavController()
     NotificationScreen(
-        navController = navController,
-        onMyAlarmSettingClicked = {}
+        onMyAlarmSettingClicked = {},
+        onMyFavoriteShowsClicked = {},
+        onMyFinishedShowClicked = {}
     )
 }
 
 @Composable
 fun NotificationScreen(
-    navController: NavController,
     onMyAlarmSettingClicked: () -> Unit,
+    onMyFavoriteShowsClicked: () -> Unit,
+    onMyFinishedShowClicked: () -> Unit,
 ) {
     NotificationScreenContent(
-        onMyAlarmSettingClicked = onMyAlarmSettingClicked,
+        onMyAlarmSettingClicked = {
+            onMyAlarmSettingClicked()
+        },
+        onMyFavoriteShowsClicked = {
+            onMyFavoriteShowsClicked()
+        },
+        onMyFinishedShowClicked = {
+            onMyFinishedShowClicked()
+        }
     )
 }
 
@@ -49,6 +58,8 @@ fun NotificationScreen(
 @Composable
 fun NotificationScreenContent(
     onMyAlarmSettingClicked: () -> Unit,
+    onMyFavoriteShowsClicked: () -> Unit,
+    onMyFinishedShowClicked: () -> Unit,
 ) {
 
     val pagerState = rememberPagerState(pageCount = { 5 })
@@ -121,28 +132,26 @@ fun NotificationScreenContent(
             item {
                 Spacer(Modifier.height(12.dp))
             }
-
+            // 관심 공연
             item {
                 IconMenuWithCount(
                     firstIcon = painterResource(id = com.alreadyoccupiedseat.designsystem.R.drawable.ic_heart_24),
                     title = stringResource(com.alreadyoccupiedseat.designsystem.R.string.favorite_shows),
                     count = 3,
                 ) {
-
+                    onMyFavoriteShowsClicked()
                 }
             }
 
-            item {
-                Spacer(Modifier.height(12.dp))
-            }
-
+            item { Spacer(Modifier.height(12.dp)) }
+            // 티켓팅 종료 공연
             item {
                 IconMenuWithCount(
                     firstIcon = painterResource(id = com.alreadyoccupiedseat.designsystem.R.drawable.ic_ticket_close_24), // Todo: Change Icon (?) -> 작아보임
                     title = stringResource(com.alreadyoccupiedseat.designsystem.R.string.close_ticketing_shows),
                     count = 5,
                 ) {
-
+                    onMyFinishedShowClicked()
                 }
             }
         }


### PR DESCRIPTION
## 🤘 작업 내용
- 내 알림 화면의 메뉴들 변경 
- 관심 공연, 티켓팅 종료 공연 메뉴 추가 
- 관심 공연, 티켓팅 종료 공연 메뉴 화면 연결 

## 💻 동작 화면
![Aug-24-2024 15-03-59](https://github.com/user-attachments/assets/a1b2bdd9-0c53-4689-99aa-b103cdd169f9)


## 📌 비고
- 내 알림 아이콘 업데이트 전, 종 모양 유지 
- 추후에 업데이트되면 변경
