### PR TITLE
아티스트 구독 기능 구현, 로그인 판정 처리 이슈 해결

### DIFF
--- a/app/src/main/java/com/alreadyoccupiedseat/showpot/MainActivity.kt
+++ b/app/src/main/java/com/alreadyoccupiedseat/showpot/MainActivity.kt
@@ -6,11 +6,8 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.annotation.RequiresApi
-import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.alreadyoccupiedseat.core.LocalAccessToken
 import com.alreadyoccupiedseat.designsystem.ShowPotTheme
 import com.alreadyoccupiedseat.onboarding.OnboardingScreen
 import com.alreadyoccupiedseat.showpot.ui.AppScreen
@@ -18,8 +15,6 @@ import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
-
-    private var accessToken: String? = null
 
     @RequiresApi(Build.VERSION_CODES.TIRAMISU)
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -31,38 +26,30 @@ class MainActivity : ComponentActivity() {
             // ex) do not let them see the onboarding screen "at all" if they have already completed it
             ShowPotTheme {
 
-                CompositionLocalProvider(LocalAccessToken provides accessToken) {
 
-                    EssentialPermissionDialog()
+                EssentialPermissionDialog()
 
-                    val viewModel = hiltViewModel<MainActivityViewModel>()
-                    val state = viewModel.state.collectAsState()
+                val viewModel = hiltViewModel<MainActivityViewModel>()
+                val state = viewModel.state.collectAsState()
 
-                    // 최상단 상태에서 LocalAccessToken으로 로그인 여부를 확인
-                    // null 이라면 비로그인 상태
-                    LaunchedEffect(true) {
-                        viewModel.setInitAccessToken {
-                            accessToken = it
-                        }
+
+                when (state.value.isOnboardingCompleted) {
+
+                    OnboardingCheckState.OnBoardingInit, OnboardingCheckState.OnBoardingChecking -> {
+                        // TODO: Splash for Loading
                     }
 
-                    when (state.value.isOnboardingCompleted) {
+                    OnboardingCheckState.OnBoardingDone -> {
+                        AppScreen()
+                    }
 
-                        OnboardingCheckState.OnBoardingInit, OnboardingCheckState.OnBoardingChecking -> {
-                            // TODO: Splash for Loading
-                        }
-
-                        OnboardingCheckState.OnBoardingDone -> {
-                            AppScreen()
-                        }
-
-                        OnboardingCheckState.OnBoardingIsNotDone -> {
-                            OnboardingScreen {
-                                viewModel.onboardingCompleted()
-                            }
+                    OnboardingCheckState.OnBoardingIsNotDone -> {
+                        OnboardingScreen {
+                            viewModel.onboardingCompleted()
                         }
                     }
                 }
+
             }
         }
     }

--- a/app/src/main/java/com/alreadyoccupiedseat/showpot/MainActivityViewModel.kt
+++ b/app/src/main/java/com/alreadyoccupiedseat/showpot/MainActivityViewModel.kt
@@ -53,6 +53,8 @@ class MainActivityViewModel @Inject constructor(
 
         }
 
+        refreshTokens()
+
     }
 
     fun onboardingCompleted() {
@@ -60,26 +62,11 @@ class MainActivityViewModel @Inject constructor(
             state.value.copy(isOnboardingCompleted = OnboardingCheckState.OnBoardingDone)
     }
 
-    // 초기 엑세스 토큰을 가져오기
-    // 토큰이 없다면 null로 설정
-    // 토큰이 있다면 토큰을 갱신하고 갱신된 토큰으로 설정
-    fun setInitAccessToken(onGetAccessTokenSuccess: (String?) -> Unit) {
+    private fun refreshTokens() {
         viewModelScope.launch {
-            val firstAccessToken = accountDataStore.getAccessToken()
-            if (firstAccessToken != null) {
-                refreshTokens { updatedAccessToken ->
-                    onGetAccessTokenSuccess(updatedAccessToken)
-                }
-            } else {
-                onGetAccessTokenSuccess(null)
+            accountDataStore.getRefreshToken()?.let {
+                reIssueTokenUseCase()
             }
-        }
-    }
-
-    private fun refreshTokens(onRefreshSuccess: (String?) -> Unit) {
-        viewModelScope.launch {
-            reIssueTokenUseCase()
-            onRefreshSuccess(accountDataStore.getAccessToken())
         }
     }
 

--- a/app/src/main/java/com/alreadyoccupiedseat/showpot/ui/AppScreen.kt
+++ b/app/src/main/java/com/alreadyoccupiedseat/showpot/ui/AppScreen.kt
@@ -138,7 +138,9 @@ fun AppScreenContent() {
             }
 
             composable(Screen.SubscriptionArtist.route) {
-                SubscriptionArtistScreen(navController)
+                SubscriptionArtistScreen(navController) {
+                    navController.navigate(Screen.Login.route)
+                }
             }
 
             composable(Screen.SubscribedArtist.route) {

--- a/core/data/src/main/java/com/alreadyoccupiedseat/data/artist/ArtistDataSource.kt
+++ b/core/data/src/main/java/com/alreadyoccupiedseat/data/artist/ArtistDataSource.kt
@@ -19,4 +19,8 @@ interface ArtistDataSource {
         cursor: String? = null,
         size: Int,
     ): List<Artist>
+
+    suspend fun subscribeArtists(
+        artistIds: List<String>,
+    ): List<String>
 }

--- a/core/data/src/main/java/com/alreadyoccupiedseat/data/artist/ArtistDataSource.kt
+++ b/core/data/src/main/java/com/alreadyoccupiedseat/data/artist/ArtistDataSource.kt
@@ -10,4 +10,13 @@ interface ArtistDataSource {
         size: Int,
         search: String,
     ): List<Artist>
+
+    suspend fun getUnsubscribedArtists(
+        sortedStandard: String? = null,
+        artistGenderApiTypes: List<String>? = null,
+        artistApiTypes: List<String>? = null,
+        genreIds: List<String>? = null,
+        cursor: String? = null,
+        size: Int,
+    ): List<Artist>
 }

--- a/core/data/src/main/java/com/alreadyoccupiedseat/data/artist/ArtistDataSourceImpl.kt
+++ b/core/data/src/main/java/com/alreadyoccupiedseat/data/artist/ArtistDataSourceImpl.kt
@@ -21,4 +21,22 @@ class ArtistDataSourceImpl @Inject constructor(
             search,
         ).body()?.data ?: emptyList()
     }
+
+    override suspend fun getUnsubscribedArtists(
+        sortedStandard: String?,
+        artistGenderApiTypes: List<String>?,
+        artistApiTypes: List<String>?,
+        genreIds: List<String>?,
+        cursor: String?,
+        size: Int,
+    ): List<Artist> {
+        return artistService.getUnsubscribedArtists(
+            sortedStandard,
+            artistGenderApiTypes,
+            artistApiTypes,
+            genreIds,
+            cursor,
+            size,
+        ).body()?.data ?: emptyList()
+    }
 }

--- a/core/data/src/main/java/com/alreadyoccupiedseat/data/artist/ArtistDataSourceImpl.kt
+++ b/core/data/src/main/java/com/alreadyoccupiedseat/data/artist/ArtistDataSourceImpl.kt
@@ -1,6 +1,7 @@
 package com.alreadyoccupiedseat.data.artist
 
 import com.alreadyoccupiedseat.model.Artist
+import com.alreadyoccupiedseat.model.artist.SubscribeArtistsRequest
 import com.alreadyoccupiedseat.network.ArtistService
 import javax.inject.Inject
 
@@ -38,5 +39,10 @@ class ArtistDataSourceImpl @Inject constructor(
             cursor,
             size,
         ).body()?.data ?: emptyList()
+    }
+
+    override suspend fun subscribeArtists(artistIds: List<String>): List<String> {
+        return artistService.subscribeArtists(SubscribeArtistsRequest(artistIds))
+            .body()?.successSubscriptionArtistIds ?: emptyList()
     }
 }

--- a/core/data/src/main/java/com/alreadyoccupiedseat/data/artist/ArtistRepository.kt
+++ b/core/data/src/main/java/com/alreadyoccupiedseat/data/artist/ArtistRepository.kt
@@ -19,4 +19,8 @@ interface ArtistRepository {
         cursor: String? = null,
         size: Int,
     ): List<Artist>
+
+    suspend fun subscribeArtists(
+        artistIds: List<String>,
+    ): List<String>
 }

--- a/core/data/src/main/java/com/alreadyoccupiedseat/data/artist/ArtistRepository.kt
+++ b/core/data/src/main/java/com/alreadyoccupiedseat/data/artist/ArtistRepository.kt
@@ -10,4 +10,13 @@ interface ArtistRepository {
         size: Int,
         search: String,
     ): List<Artist>
+
+    suspend fun getUnsubscribedArtists(
+        sortedStandard: String? = null,
+        artistGenderApiTypes: List<String>? = null,
+        artistApiTypes: List<String>? = null,
+        genreIds: List<String>? = null,
+        cursor: String? = null,
+        size: Int,
+    ): List<Artist>
 }

--- a/core/data/src/main/java/com/alreadyoccupiedseat/data/artist/ArtistRepositoryImpl.kt
+++ b/core/data/src/main/java/com/alreadyoccupiedseat/data/artist/ArtistRepositoryImpl.kt
@@ -20,4 +20,22 @@ class ArtistRepositoryImpl @Inject constructor(
             search,
         )
     }
+
+    override suspend fun getUnsubscribedArtists(
+        sortedStandard: String?,
+        artistGenderApiTypes: List<String>?,
+        artistApiTypes: List<String>?,
+        genreIds: List<String>?,
+        cursor: String?,
+        size: Int,
+    ): List<Artist> {
+        return artistDataSource.getUnsubscribedArtists(
+            sortedStandard,
+            artistGenderApiTypes,
+            artistApiTypes,
+            genreIds,
+            cursor,
+            size,
+        )
+    }
 }

--- a/core/data/src/main/java/com/alreadyoccupiedseat/data/artist/ArtistRepositoryImpl.kt
+++ b/core/data/src/main/java/com/alreadyoccupiedseat/data/artist/ArtistRepositoryImpl.kt
@@ -38,4 +38,8 @@ class ArtistRepositoryImpl @Inject constructor(
             size,
         )
     }
+
+    override suspend fun subscribeArtists(artistIds: List<String>): List<String> {
+        return artistDataSource.subscribeArtists(artistIds)
+    }
 }

--- a/core/network/src/main/java/com/alreadyoccupiedseat/network/ArtistService.kt
+++ b/core/network/src/main/java/com/alreadyoccupiedseat/network/ArtistService.kt
@@ -2,8 +2,12 @@ package com.alreadyoccupiedseat.network
 
 import com.alreadyoccupiedseat.model.Artist
 import com.alreadyoccupiedseat.model.PagingData
+import com.alreadyoccupiedseat.model.artist.SubscribeArtistsRequest
+import com.alreadyoccupiedseat.model.artist.SubscribeArtistsResponse
 import retrofit2.Response
+import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.POST
 import retrofit2.http.Query
 
 interface ArtistService {
@@ -25,4 +29,9 @@ interface ArtistService {
         @Query("cursor") cursor: String? = null,
         @Query("size") size: Int,
     ): Response<PagingData<Artist>>
+
+    @POST("api/v1/artists/subscribe")
+    suspend fun subscribeArtists(
+        @Body artistIds: SubscribeArtistsRequest,
+    ): Response<SubscribeArtistsResponse>
 }

--- a/core/network/src/main/java/com/alreadyoccupiedseat/network/ArtistService.kt
+++ b/core/network/src/main/java/com/alreadyoccupiedseat/network/ArtistService.kt
@@ -9,10 +9,20 @@ import retrofit2.http.Query
 interface ArtistService {
 
     @GET("api/v1/artists/search")
-    suspend fun  searchArtists(
+    suspend fun searchArtists(
         @Query("sortedStandard") sortedStandard: String? = null,
         @Query("cursor") cursor: String? = null,
         @Query("size") size: Int,
         @Query("search") search: String,
+    ): Response<PagingData<Artist>>
+
+    @GET("api/v1/artists/unsubscriptions")
+    suspend fun getUnsubscribedArtists(
+        @Query("sortedStandard") sortedStandard: String? = null,
+        @Query("artistGenderApiTypes") artistGenderApiTypes: List<String>? = null,
+        @Query("artistApiTypes") artistApiTypes: List<String>? = null,
+        @Query("genreIds") genreIds: List<String>? = null,
+        @Query("cursor") cursor: String? = null,
+        @Query("size") size: Int,
     ): Response<PagingData<Artist>>
 }

--- a/core/network/src/main/java/com/alreadyoccupiedseat/network/AuthInterceptor.kt
+++ b/core/network/src/main/java/com/alreadyoccupiedseat/network/AuthInterceptor.kt
@@ -33,7 +33,8 @@ class AuthInterceptor @Inject constructor(
 
         val accessToken = dataStore.getAccessToken()
 
-        val token = if (accessToken != null) "Bearer $accessToken" else ""
+        val token = if (accessToken != null) "Bearer $accessToken"
+        else return chain.proceed(chain.request().newBuilder().build())
         val newRequest = chain.request().newBuilder()
             .addHeader("Authorization", token)
             .build()

--- a/feature/subscription-artist/build.gradle.kts
+++ b/feature/subscription-artist/build.gradle.kts
@@ -39,6 +39,7 @@ dependencies {
     implementation(project(":core:designsystem"))
     implementation(project(":core:datastore"))
     implementation(project(":core:common"))
+    implementation(project(":core:data"))
     implementation(project(":model"))
 
     implementation(libs.androidx.lifecycle.runtime.ktx)

--- a/feature/subscription-artist/src/main/java/com/alreadyoccupiedseat/subscription_artist/SubscriptionArtistScreen.kt
+++ b/feature/subscription-artist/src/main/java/com/alreadyoccupiedseat/subscription_artist/SubscriptionArtistScreen.kt
@@ -33,33 +33,45 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
+import com.alreadyoccupiedseat.core.LocalAccessToken
 import com.alreadyoccupiedseat.designsystem.ShowpotColor
-import com.alreadyoccupiedseat.designsystem.component.artistByPainter.ShowPotArtistSubscriptionByPainter
 import com.alreadyoccupiedseat.designsystem.component.ShowPotMainButton
+import com.alreadyoccupiedseat.designsystem.component.artist.ShowPotArtistSubscription
 import com.alreadyoccupiedseat.designsystem.component.bottomSheet.SheetHandler
 import com.alreadyoccupiedseat.designsystem.component.bottomSheet.ShowPotBottomSheet
 import com.alreadyoccupiedseat.designsystem.component.snackbar.CheckIconSnackbar
 import com.alreadyoccupiedseat.designsystem.typo.korean.ShowPotKoreanText_H1
 import com.alreadyoccupiedseat.designsystem.typo.korean.ShowPotKoreanText_H2
+import com.alreadyoccupiedseat.model.Artist
 import kotlinx.coroutines.launch
 
 @Composable
 fun SubscriptionArtistScreen(
     navController: NavController,
+    onLoginRequested: () -> Unit = {},
 ) {
 
     val viewModel = hiltViewModel<SubscriptionArtistViewModel>()
+    val state = viewModel.state.collectAsState()
     val event = viewModel.event.collectAsState()
 
     when (event.value) {
         SubscriptionArtistScreenEvent.Idle -> {
             SubscriptionArtistScreenContent(
+                state = state.value,
                 onBackClicked = {
                     navController.popBackStack()
                 },
                 onSubscribeButtonClicked = {
                     viewModel.subscribeArtists()
-                }
+                },
+                onArtistClicked = {
+                    viewModel.selectArtist(it)
+                },
+                checkIsSelected = {
+                    viewModel.isSelected(it)
+                },
+                onLoginRequested = onLoginRequested
             )
         }
 
@@ -69,15 +81,20 @@ fun SubscriptionArtistScreen(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SubscriptionArtistScreenContent(
+    state: SubscriptionArtistScreenState,
     onBackClicked: () -> Unit,
     onSubscribeButtonClicked: () -> Unit = {},
+    onArtistClicked: (Artist) -> Unit = {},
+    checkIsSelected: (Artist) -> Boolean,
+    onLoginRequested: () -> Unit = {},
 ) {
 
     val scope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
 
+    val isLoggedIn = LocalAccessToken.current != null
     // TODO: Supposed to be in a ViewModel State
-    var isSheetVisible by remember { mutableStateOf(true) }
+    var isSheetVisible by remember { mutableStateOf(false) }
 
     if (isSheetVisible) {
 
@@ -107,7 +124,7 @@ fun SubscriptionArtistScreenContent(
                     modifier = Modifier.fillMaxWidth(),
                     text = "3초만에 로그인하기"
                 ) {
-                    // TODO: goto Login
+                    onLoginRequested()
                 }
 
                 Spacer(modifier = Modifier.height(54.dp))
@@ -115,8 +132,6 @@ fun SubscriptionArtistScreenContent(
         }
 
     }
-
-
 
     Scaffold(
         modifier = Modifier
@@ -190,12 +205,19 @@ fun SubscriptionArtistScreenContent(
                     verticalArrangement = Arrangement.spacedBy(20.dp)
                 ) {
                     // TODO: Real Data
-                    items(count = 21) {
-                        ShowPotArtistSubscriptionByPainter(
-                            text = "High Flying Birds",
-                            icon = painterResource(id = com.alreadyoccupiedseat.designsystem.R.drawable.img_artist_default),
+
+                    items(state.unsubscribedArtists.size) { index ->
+                        val curArtist = state.unsubscribedArtists[index]
+                        ShowPotArtistSubscription(
+                            text = curArtist.englishName,
+                            imageUrl = curArtist.imageUrl,
+                            isSelected = checkIsSelected(curArtist),
                         ) {
-                            isSheetVisible = true
+                            if (isLoggedIn) {
+                                isSheetVisible = true
+                            } else {
+                                onArtistClicked(curArtist)
+                            }
                         }
                     }
 

--- a/feature/subscription-artist/src/main/java/com/alreadyoccupiedseat/subscription_artist/SubscriptionArtistScreen.kt
+++ b/feature/subscription-artist/src/main/java/com/alreadyoccupiedseat/subscription_artist/SubscriptionArtistScreen.kt
@@ -1,5 +1,6 @@
 package com.alreadyoccupiedseat.subscription_artist
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -33,7 +34,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
-import com.alreadyoccupiedseat.core.LocalAccessToken
 import com.alreadyoccupiedseat.designsystem.ShowpotColor
 import com.alreadyoccupiedseat.designsystem.component.ShowPotMainButton
 import com.alreadyoccupiedseat.designsystem.component.artist.ShowPotArtistSubscription
@@ -78,7 +78,7 @@ fun SubscriptionArtistScreen(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun SubscriptionArtistScreenContent(
     state: SubscriptionArtistScreenState,
@@ -92,7 +92,6 @@ fun SubscriptionArtistScreenContent(
     val scope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
 
-    val isLoggedIn = LocalAccessToken.current != null
     // TODO: Supposed to be in a ViewModel State
     var isSheetVisible by remember { mutableStateOf(false) }
 
@@ -213,7 +212,7 @@ fun SubscriptionArtistScreenContent(
                             imageUrl = curArtist.imageUrl,
                             isSelected = checkIsSelected(curArtist),
                         ) {
-                            if (isLoggedIn) {
+                            if (state.isLoggedIn.not()) {
                                 isSheetVisible = true
                             } else {
                                 onArtistClicked(curArtist)

--- a/feature/subscription-artist/src/main/java/com/alreadyoccupiedseat/subscription_artist/SubscriptionArtistViewModel.kt
+++ b/feature/subscription-artist/src/main/java/com/alreadyoccupiedseat/subscription_artist/SubscriptionArtistViewModel.kt
@@ -2,10 +2,9 @@ package com.alreadyoccupiedseat.subscription_artist
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.alreadyoccupiedseat.core.extension.EMPTY
 import com.alreadyoccupiedseat.data.artist.ArtistRepository
+import com.alreadyoccupiedseat.datastore.AccountDataStore
 import com.alreadyoccupiedseat.model.Artist
-import com.alreadyoccupiedseat.model.Show
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
@@ -18,16 +17,23 @@ sealed interface SubscriptionArtistScreenEvent {
 data class SubscriptionArtistScreenState(
     val selectedArtists: List<Artist> = emptyList(),
     val unsubscribedArtists: List<Artist> = emptyList(),
+    val isLoggedIn: Boolean = false
 )
 
 
 @HiltViewModel
 class SubscriptionArtistViewModel @Inject constructor(
     private val artistRepository: ArtistRepository,
+    private val accountDataStore: AccountDataStore
 ) : ViewModel() {
 
     init {
         getUnsubscribedArtists()
+        viewModelScope.launch {
+            accountDataStore.getAccessToken()?.let {
+                _state.value = _state.value.copy(isLoggedIn = true)
+            }
+        }
     }
 
     private var _state = MutableStateFlow(SubscriptionArtistScreenState())
@@ -37,7 +43,12 @@ class SubscriptionArtistViewModel @Inject constructor(
 
     fun subscribeArtists() {
         viewModelScope.launch {
-
+            val artistIds = state.value.selectedArtists.map { it.id }
+            val subscribedArtistsIds = artistRepository.subscribeArtists(artistIds)
+            _state.value = _state.value.copy(
+                selectedArtists = emptyList(),
+                unsubscribedArtists = state.value.unsubscribedArtists.filter { it.id !in subscribedArtistsIds },
+            )
         }
     }
 
@@ -59,7 +70,7 @@ class SubscriptionArtistViewModel @Inject constructor(
         return state.value.selectedArtists.contains(artist)
     }
 
-    fun getUnsubscribedArtists() {
+    private fun getUnsubscribedArtists() {
         viewModelScope.launch {
             val result = artistRepository.getUnsubscribedArtists(
                 size = 100,

--- a/feature/subscription-artist/src/main/java/com/alreadyoccupiedseat/subscription_artist/SubscriptionArtistViewModel.kt
+++ b/feature/subscription-artist/src/main/java/com/alreadyoccupiedseat/subscription_artist/SubscriptionArtistViewModel.kt
@@ -3,8 +3,10 @@ package com.alreadyoccupiedseat.subscription_artist
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.alreadyoccupiedseat.core.extension.EMPTY
+import com.alreadyoccupiedseat.data.artist.ArtistRepository
 import com.alreadyoccupiedseat.model.Artist
 import com.alreadyoccupiedseat.model.Show
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -15,17 +17,57 @@ sealed interface SubscriptionArtistScreenEvent {
 
 data class SubscriptionArtistScreenState(
     val selectedArtists: List<Artist> = emptyList(),
+    val unsubscribedArtists: List<Artist> = emptyList(),
 )
 
 
-class SubscriptionArtistViewModel @Inject constructor(): ViewModel() {
+@HiltViewModel
+class SubscriptionArtistViewModel @Inject constructor(
+    private val artistRepository: ArtistRepository,
+) : ViewModel() {
 
-    val state = MutableStateFlow(SubscriptionArtistScreenState())
+    init {
+        getUnsubscribedArtists()
+    }
+
+    private var _state = MutableStateFlow(SubscriptionArtistScreenState())
+    val state = _state
+
     val event = MutableStateFlow(SubscriptionArtistScreenEvent.Idle)
 
     fun subscribeArtists() {
         viewModelScope.launch {
 
+        }
+    }
+
+    fun selectArtist(artist: Artist) {
+
+        if (state.value.selectedArtists.contains(artist)) {
+            _state.value = _state.value.copy(
+                selectedArtists = _state.value.selectedArtists - artist,
+            )
+        } else {
+            _state.value = _state.value.copy(
+                selectedArtists = _state.value.selectedArtists + artist,
+            )
+        }
+
+    }
+
+    fun isSelected(artist: Artist): Boolean {
+        return state.value.selectedArtists.contains(artist)
+    }
+
+    fun getUnsubscribedArtists() {
+        viewModelScope.launch {
+            val result = artistRepository.getUnsubscribedArtists(
+                size = 100,
+            )
+
+            _state.value = _state.value.copy(
+                unsubscribedArtists = result,
+            )
         }
     }
 }

--- a/model/src/main/java/com/alreadyoccupiedseat/model/artist/SubscribeArtistsRequest.kt
+++ b/model/src/main/java/com/alreadyoccupiedseat/model/artist/SubscribeArtistsRequest.kt
@@ -1,0 +1,5 @@
+package com.alreadyoccupiedseat.model.artist
+
+data class SubscribeArtistsRequest(
+    val artistIds: List<String>
+)

--- a/model/src/main/java/com/alreadyoccupiedseat/model/artist/SubscribeArtistsResponse.kt
+++ b/model/src/main/java/com/alreadyoccupiedseat/model/artist/SubscribeArtistsResponse.kt
@@ -1,0 +1,5 @@
+package com.alreadyoccupiedseat.model.artist
+
+data class SubscribeArtistsResponse(
+    val successSubscriptionArtistIds: List<String>
+)


### PR DESCRIPTION
## 🤘 작업 내용
- 아티스트 구독 기능 구현
- 로그인 판정 처리 이슈 해결
  - 각 화면에서 엑세스 토큰여부를 확인하는 로직으로 처리 

## 📋 변경된 내용
- CompositionLocal로 관리하던 로그인 판정 여부를, 각 화면에서 엑세스 토큰 여부를 확인하는 로직으로 변경
- 헤더 인터셉터에서 엑세스 토큰이 없을 때 공백으로 토큰을 보내던 이슈 해결

## 💻 동작 화면
- 동작 화면 없음

## 📌 비고
- 비고 없음
