### PR TITLE
공용 컴포넌트 공연 티켓 기본 가로 패딩 값 삭제

### DIFF
--- a/core/designsystem/src/main/java/com/alreadyoccupiedseat/designsystem/component/ShowPotTicket.kt
+++ b/core/designsystem/src/main/java/com/alreadyoccupiedseat/designsystem/component/ShowPotTicket.kt
@@ -123,10 +123,7 @@ fun ShowPotTicket(
                 horizontalAlignment = Alignment.Start,
                 modifier = Modifier
                     .width(210.dp)
-                    .padding(
-                        vertical = 12.5.dp,
-                        horizontal = 16.dp
-                    )
+                    .padding(vertical = 12.5.dp,)
             ) {
 
                 Row(


### PR DESCRIPTION
## 🤘 작업 내용
- 공용 컴포넌트 공연 티켓, 기본 가로 패딩 값 삭제
