### PR TITLE
아티스트 구독 화면에서 구독 버튼 아래 그라데이션 추가 및 선택된 아티스트일 때만 구독하기 버튼을 보여주도록 변경

### DIFF
--- a/feature/subscription-artist/src/main/java/com/alreadyoccupiedseat/subscription_artist/SubscriptionArtistScreen.kt
+++ b/feature/subscription-artist/src/main/java/com/alreadyoccupiedseat/subscription_artist/SubscriptionArtistScreen.kt
@@ -21,11 +21,8 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -62,6 +59,9 @@ fun SubscriptionArtistScreen(
                 onBackClicked = {
                     navController.popBackStack()
                 },
+                onSheetStateChanged = { isVisible ->
+                    viewModel.setSheetVisible(isVisible)
+                },
                 onSubscribeButtonClicked = {
                     viewModel.subscribeArtists()
                 },
@@ -83,6 +83,7 @@ fun SubscriptionArtistScreen(
 fun SubscriptionArtistScreenContent(
     state: SubscriptionArtistScreenState,
     onBackClicked: () -> Unit,
+    onSheetStateChanged: (Boolean) -> Unit = {},
     onSubscribeButtonClicked: () -> Unit = {},
     onArtistClicked: (Artist) -> Unit = {},
     checkIsSelected: (Artist) -> Boolean,
@@ -92,14 +93,11 @@ fun SubscriptionArtistScreenContent(
     val scope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
 
-    // TODO: Supposed to be in a ViewModel State
-    var isSheetVisible by remember { mutableStateOf(false) }
-
-    if (isSheetVisible) {
+    if (state.isSheetVisible) {
 
         ShowPotBottomSheet(
             onDismissRequest = {
-                isSheetVisible = false
+                onSheetStateChanged(false)
             },
         ) {
             Column(
@@ -213,7 +211,7 @@ fun SubscriptionArtistScreenContent(
                             isSelected = checkIsSelected(curArtist),
                         ) {
                             if (state.isLoggedIn.not()) {
-                                isSheetVisible = true
+                                onSheetStateChanged(true)
                             } else {
                                 onArtistClicked(curArtist)
                             }

--- a/feature/subscription-artist/src/main/java/com/alreadyoccupiedseat/subscription_artist/SubscriptionArtistScreen.kt
+++ b/feature/subscription-artist/src/main/java/com/alreadyoccupiedseat/subscription_artist/SubscriptionArtistScreen.kt
@@ -1,6 +1,10 @@
 package com.alreadyoccupiedseat.subscription_artist
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -25,6 +29,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -221,21 +226,39 @@ fun SubscriptionArtistScreenContent(
                 }
 
                 // Todo: Visibility depends on whether artists are selected
-                Box(
-                    modifier = Modifier
-                        .padding(top = 4.dp)
-                        .fillMaxWidth()
-                        .padding(bottom = 54.dp),
+                this@Column.AnimatedVisibility(
+                    visible = state.selectedArtists.isNotEmpty(),
+                    enter = slideInVertically(
+                        initialOffsetY = { fullHeight -> fullHeight },
+                    ),
+                    exit = slideOutVertically(
+                        targetOffsetY = { fullHeight -> fullHeight }
+                    )
                 ) {
-                    ShowPotMainButton(
+                    Box(
                         modifier = Modifier
-                            .padding(horizontal = 20.dp)
-                            .fillMaxWidth(),
-                        text = stringResource(R.string.subscribe)
+                            .padding(top = 4.dp)
+                            .fillMaxWidth()
+                            .background(
+                                brush = Brush.verticalGradient(
+                                    colors = listOf(
+                                        ShowpotColor.Gray700.copy(alpha = 0f),
+                                        ShowpotColor.Gray700
+                                    ),
+                                )
+                            )
+                            .padding(bottom = 54.dp),
                     ) {
-                        scope.launch {
-                            onSubscribeButtonClicked()
-                            snackbarHostState.showSnackbar("구독 설정이 완료되었습니다")
+                        ShowPotMainButton(
+                            modifier = Modifier
+                                .padding(horizontal = 20.dp)
+                                .fillMaxWidth(),
+                            text = stringResource(R.string.subscribe)
+                        ) {
+                            scope.launch {
+                                onSubscribeButtonClicked()
+                                snackbarHostState.showSnackbar("구독 설정이 완료되었습니다")
+                            }
                         }
                     }
                 }

--- a/feature/subscription-artist/src/main/java/com/alreadyoccupiedseat/subscription_artist/SubscriptionArtistViewModel.kt
+++ b/feature/subscription-artist/src/main/java/com/alreadyoccupiedseat/subscription_artist/SubscriptionArtistViewModel.kt
@@ -17,7 +17,8 @@ sealed interface SubscriptionArtistScreenEvent {
 data class SubscriptionArtistScreenState(
     val selectedArtists: List<Artist> = emptyList(),
     val unsubscribedArtists: List<Artist> = emptyList(),
-    val isLoggedIn: Boolean = false
+    val isLoggedIn: Boolean = false,
+    val isSheetVisible: Boolean = false,
 )
 
 
@@ -68,6 +69,12 @@ class SubscriptionArtistViewModel @Inject constructor(
 
     fun isSelected(artist: Artist): Boolean {
         return state.value.selectedArtists.contains(artist)
+    }
+
+    fun setSheetVisible(isVisible: Boolean) {
+        _state.value = _state.value.copy(
+            isSheetVisible = isVisible,
+        )
     }
 
     private fun getUnsubscribedArtists() {


### PR DESCRIPTION
## 🤘 작업 내용
- 구독 버튼 아래 그라데이션 추가
- 선택된 아티스트일 때만 구독하기 버튼을 보여주도록 변경

## 📋 변경된 내용
- 구독 버튼 아래 그라데이션 추가
- 선택된 아티스트일 때만 구독하기 버튼을 보여주도록 변경

## 💻 동작 화면
![subcribe_button_gradation](https://github.com/user-attachments/assets/951e0548-df60-4aeb-8180-d789c53f1d97)


## 📌 비고
- 스낵바 상태 처리, 이벤트로 분리해서 적용할 예정
