### PR TITLE
아티스트 검색 ui 일부 수정(구독 여부 확인 후 각기 다른 아이콘 보여줌, 구독 해제 바텀시트)

### DIFF
--- a/core/data/src/main/java/com/alreadyoccupiedseat/data/artist/ArtistDataSource.kt
+++ b/core/data/src/main/java/com/alreadyoccupiedseat/data/artist/ArtistDataSource.kt
@@ -1,6 +1,7 @@
 package com.alreadyoccupiedseat.data.artist
 
 import com.alreadyoccupiedseat.model.Artist
+import com.alreadyoccupiedseat.model.SubscribedArtist
 
 interface ArtistDataSource {
 
@@ -9,7 +10,7 @@ interface ArtistDataSource {
         cursor: String? = null,
         size: Int,
         search: String,
-    ): List<Artist>
+    ): List<SubscribedArtist>
 
     suspend fun getUnsubscribedArtists(
         sortedStandard: String? = null,

--- a/core/data/src/main/java/com/alreadyoccupiedseat/data/artist/ArtistDataSourceImpl.kt
+++ b/core/data/src/main/java/com/alreadyoccupiedseat/data/artist/ArtistDataSourceImpl.kt
@@ -1,6 +1,7 @@
 package com.alreadyoccupiedseat.data.artist
 
 import com.alreadyoccupiedseat.model.Artist
+import com.alreadyoccupiedseat.model.SubscribedArtist
 import com.alreadyoccupiedseat.model.artist.SubscribeArtistsRequest
 import com.alreadyoccupiedseat.network.ArtistService
 import javax.inject.Inject
@@ -14,7 +15,7 @@ class ArtistDataSourceImpl @Inject constructor(
         cursor: String?,
         size: Int,
         search: String,
-    ): List<Artist> {
+    ): List<SubscribedArtist> {
         return artistService.searchArtists(
             sortedStandard,
             cursor,

--- a/core/data/src/main/java/com/alreadyoccupiedseat/data/artist/ArtistRepository.kt
+++ b/core/data/src/main/java/com/alreadyoccupiedseat/data/artist/ArtistRepository.kt
@@ -1,6 +1,7 @@
 package com.alreadyoccupiedseat.data.artist
 
 import com.alreadyoccupiedseat.model.Artist
+import com.alreadyoccupiedseat.model.SubscribedArtist
 
 interface ArtistRepository {
 
@@ -9,7 +10,7 @@ interface ArtistRepository {
         cursor: String? = null,
         size: Int,
         search: String,
-    ): List<Artist>
+    ): List<SubscribedArtist>
 
     suspend fun getUnsubscribedArtists(
         sortedStandard: String? = null,

--- a/core/data/src/main/java/com/alreadyoccupiedseat/data/artist/ArtistRepositoryImpl.kt
+++ b/core/data/src/main/java/com/alreadyoccupiedseat/data/artist/ArtistRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.alreadyoccupiedseat.data.artist
 
 import com.alreadyoccupiedseat.model.Artist
+import com.alreadyoccupiedseat.model.SubscribedArtist
 import javax.inject.Inject
 
 class ArtistRepositoryImpl @Inject constructor(
@@ -12,7 +13,7 @@ class ArtistRepositoryImpl @Inject constructor(
         cursor: String?,
         size: Int,
         search: String,
-    ): List<Artist> {
+    ): List<SubscribedArtist> {
         return artistDataSource.searchArtists(
             sortedStandard,
             cursor,

--- a/core/designsystem/src/main/java/com/alreadyoccupiedseat/designsystem/component/artist/ShowPotArtistAlarm.kt
+++ b/core/designsystem/src/main/java/com/alreadyoccupiedseat/designsystem/component/artist/ShowPotArtistAlarm.kt
@@ -17,13 +17,12 @@ import com.alreadyoccupiedseat.designsystem.R
 import com.alreadyoccupiedseat.designsystem.ShowpotColor
 
 @Composable
-fun ShowPotArtistAlarmByPainter(
+fun ShowPotArtistAlarm(
     modifier: Modifier = Modifier,
     text: String,
     imageUrl: String,
-    isSelected: Boolean = false, // 구독 버튼 컴포저블이 필요함
+    isSubscribed: Boolean = false,
     onClick: () -> Unit = {},
-    onIconClick: () -> Unit,
 ) {
     ShowPotArtist(
         imageUrl = imageUrl,
@@ -33,17 +32,19 @@ fun ShowPotArtistAlarmByPainter(
             Box(
                 modifier = modifier
                     .size(100.dp)
-                    .background(ShowpotColor.Gray700.copy(0.5f), CircleShape)
+                    .background(
+                        if (isSubscribed) ShowpotColor.MainOrange.copy(0.5f)
+                        else ShowpotColor.Gray700.copy(0.5f), CircleShape
+                    )
             ) {
                 Image(
-                    painter = painterResource(id = R.drawable.ic_alarm_plus_36),
+                    painter = if (isSubscribed) painterResource(id = R.drawable.ic_alarm_checked_36)
+                    else painterResource(id = R.drawable.ic_alarm_plus_36),
                     contentDescription = "Check",
                     colorFilter = ColorFilter.tint(Color.White),
                     modifier = modifier
                         .align(Alignment.Center)
-                        .clickable {
-                            onIconClick()
-                        }
+
                 )
             }
         }

--- a/core/designsystem/src/main/res/drawable/ic_alarm_checked_36.xml
+++ b/core/designsystem/src/main/res/drawable/ic_alarm_checked_36.xml
@@ -1,0 +1,21 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="30dp"
+    android:height="30dp"
+    android:viewportWidth="30"
+    android:viewportHeight="30">
+  <path
+      android:pathData="M12.474,27.676H17.03"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"/>
+  <path
+      android:pathData="M22.726,18.563L25.004,23.119H4.5L6.778,18.563V12.868C6.778,8.464 10.348,4.894 14.752,4.894"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"/>
+  <path
+      android:pathData="M18.188,8.514L21.689,12.016L27.915,5.79"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"/>
+</vector>

--- a/core/network/src/main/java/com/alreadyoccupiedseat/network/ArtistService.kt
+++ b/core/network/src/main/java/com/alreadyoccupiedseat/network/ArtistService.kt
@@ -2,6 +2,7 @@ package com.alreadyoccupiedseat.network
 
 import com.alreadyoccupiedseat.model.Artist
 import com.alreadyoccupiedseat.model.PagingData
+import com.alreadyoccupiedseat.model.SubscribedArtist
 import com.alreadyoccupiedseat.model.artist.SubscribeArtistsRequest
 import com.alreadyoccupiedseat.model.artist.SubscribeArtistsResponse
 import retrofit2.Response
@@ -18,7 +19,7 @@ interface ArtistService {
         @Query("cursor") cursor: String? = null,
         @Query("size") size: Int,
         @Query("search") search: String,
-    ): Response<PagingData<Artist>>
+    ): Response<PagingData<SubscribedArtist>>
 
     @GET("api/v1/artists/unsubscriptions")
     suspend fun getUnsubscribedArtists(

--- a/feature/search/src/main/java/com/alreadyoccupiedseat/search/SearchScreen.kt
+++ b/feature/search/src/main/java/com/alreadyoccupiedseat/search/SearchScreen.kt
@@ -65,6 +65,9 @@ fun SearchScreen(
         },
         onDeleteHistoryClicked = {
             viewModel.deleteSearchHistory(it)
+        },
+        onchangeArtistUnSubscriptionSheetVisibility = {
+            viewModel.changeArtistUnSubscriptionSheetVisibility(it)
         }
     )
 }
@@ -79,6 +82,7 @@ fun SearchScreenContent(
     onChipClicked: (String) -> Unit = {},
     onDeleteAllClicked: () -> Unit = {},
     onDeleteHistoryClicked: (String) -> Unit = {},
+    onchangeArtistUnSubscriptionSheetVisibility: (Boolean) -> Unit = {},
 ) {
 
     val focusManager = LocalFocusManager.current
@@ -149,9 +153,12 @@ fun SearchScreenContent(
             } else {
                 // TODO: change to real data
                 SearchedSection(
+                    isArtistUnSubscriptionSheetVisible = state.isArtistUnSubscriptionSheetVisible,
                     searchedArtists = state.searchedArtists,
                     searchedShows = state.searchedShows
-                )
+                ) {
+                    onchangeArtistUnSubscriptionSheetVisibility(it)
+                }
             }
         }
     }

--- a/feature/search/src/main/java/com/alreadyoccupiedseat/search/SearchScreen.kt
+++ b/feature/search/src/main/java/com/alreadyoccupiedseat/search/SearchScreen.kt
@@ -68,6 +68,9 @@ fun SearchScreen(
         },
         onchangeArtistUnSubscriptionSheetVisibility = {
             viewModel.changeArtistUnSubscriptionSheetVisibility(it)
+        },
+        onChangeUnSubscribeTargetArtist = {
+            viewModel.changeUnSubscribeTargetArtist(it)
         }
     )
 }
@@ -83,6 +86,7 @@ fun SearchScreenContent(
     onDeleteAllClicked: () -> Unit = {},
     onDeleteHistoryClicked: (String) -> Unit = {},
     onchangeArtistUnSubscriptionSheetVisibility: (Boolean) -> Unit = {},
+    onChangeUnSubscribeTargetArtist: (String) -> Unit = {},
 ) {
 
     val focusManager = LocalFocusManager.current
@@ -151,11 +155,14 @@ fun SearchScreenContent(
                     onDeleteHistoryClicked = onDeleteHistoryClicked
                 )
             } else {
-                // TODO: change to real data
                 SearchedSection(
                     isArtistUnSubscriptionSheetVisible = state.isArtistUnSubscriptionSheetVisible,
                     searchedArtists = state.searchedArtists,
-                    searchedShows = state.searchedShows
+                    searchedShows = state.searchedShows,
+                    unSubscribeTargetArtist = state.unSubscribeTargetArtist,
+                    onUnSubscribeTargetArtistChanged = {
+                        onChangeUnSubscribeTargetArtist(it)
+                    },
                 ) {
                     onchangeArtistUnSubscriptionSheetVisibility(it)
                 }

--- a/feature/search/src/main/java/com/alreadyoccupiedseat/search/SearchViewModel.kt
+++ b/feature/search/src/main/java/com/alreadyoccupiedseat/search/SearchViewModel.kt
@@ -8,6 +8,7 @@ import com.alreadyoccupiedseat.datastore.SearchHistoryDataStore
 import com.alreadyoccupiedseat.model.Artist
 import com.alreadyoccupiedseat.model.Genre
 import com.alreadyoccupiedseat.model.Show
+import com.alreadyoccupiedseat.model.SubscribedArtist
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
@@ -21,8 +22,9 @@ data class SearchScreenState(
     val searchHistory: List<String> = emptyList(),
     val inputText: String = String.EMPTY,
     val isSearchedScreen: Boolean = false,
-    val searchedArtists: List<Artist> = emptyList(),
+    val searchedArtists: List<SubscribedArtist> = emptyList(),
     val searchedShows: List<Show> = emptyList(),
+    val isArtistUnSubscriptionSheetVisible: Boolean = false,
 )
 
 
@@ -82,11 +84,17 @@ class SearchViewModel @Inject constructor(
         }
     }
 
+    fun changeArtistUnSubscriptionSheetVisibility(isVisible: Boolean) {
+        _state.value = _state.value.copy(
+            isArtistUnSubscriptionSheetVisible = isVisible
+        )
+    }
+
     fun searchArtistsAndShows() {
         viewModelScope.launch {
             // TODO: Changed to real data
             val searchedArtists = artistRepository.searchArtists(
-                size = 5,
+                size = 100,
                 search = _state.value.inputText,
             )
 

--- a/feature/search/src/main/java/com/alreadyoccupiedseat/search/SearchViewModel.kt
+++ b/feature/search/src/main/java/com/alreadyoccupiedseat/search/SearchViewModel.kt
@@ -25,6 +25,7 @@ data class SearchScreenState(
     val searchedArtists: List<SubscribedArtist> = emptyList(),
     val searchedShows: List<Show> = emptyList(),
     val isArtistUnSubscriptionSheetVisible: Boolean = false,
+    val unSubscribeTargetArtist: String = String.EMPTY,
 )
 
 
@@ -87,6 +88,12 @@ class SearchViewModel @Inject constructor(
     fun changeArtistUnSubscriptionSheetVisibility(isVisible: Boolean) {
         _state.value = _state.value.copy(
             isArtistUnSubscriptionSheetVisible = isVisible
+        )
+    }
+
+    fun changeUnSubscribeTargetArtist(artist: String) {
+        _state.value = _state.value.copy(
+            unSubscribeTargetArtist = artist
         )
     }
 

--- a/feature/search/src/main/java/com/alreadyoccupiedseat/search/SearchedSection.kt
+++ b/feature/search/src/main/java/com/alreadyoccupiedseat/search/SearchedSection.kt
@@ -10,24 +10,80 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.alreadyoccupiedseat.designsystem.ShowpotColor
 import com.alreadyoccupiedseat.designsystem.component.ShowInfo
-import com.alreadyoccupiedseat.designsystem.component.artist.ShowPotArtistSubscription
+import com.alreadyoccupiedseat.designsystem.component.ShowPotMainButton
+import com.alreadyoccupiedseat.designsystem.component.artist.ShowPotArtistAlarm
+import com.alreadyoccupiedseat.designsystem.component.bottomSheet.SheetHandler
+import com.alreadyoccupiedseat.designsystem.component.bottomSheet.ShowPotBottomSheet
+import com.alreadyoccupiedseat.designsystem.typo.english.ShowPotEnglishText_H1
+import com.alreadyoccupiedseat.designsystem.typo.korean.ShowPotKoreanText_H1
 import com.alreadyoccupiedseat.designsystem.typo.korean.ShowPotKoreanText_H2
-import com.alreadyoccupiedseat.model.Artist
 import com.alreadyoccupiedseat.model.Show
+import com.alreadyoccupiedseat.model.SubscribedArtist
 
 // TODO: ShowInfo
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SearchedSection(
-    searchedArtists: List<Artist>,
+    isArtistUnSubscriptionSheetVisible: Boolean,
+    searchedArtists: List<SubscribedArtist>,
     searchedShows: List<Show>,
+    onArtistUnSubscriptionSheetVisibilityChanged: (Boolean) -> Unit = {}
 ) {
+
+    if (isArtistUnSubscriptionSheetVisible) {
+
+        ShowPotBottomSheet(
+            onDismissRequest = {
+                onArtistUnSubscriptionSheetVisibilityChanged(false)
+            },
+        ) {
+            Column(
+                modifier = Modifier.fillMaxWidth()
+                    .padding(horizontal = 15.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+
+                SheetHandler()
+
+                // TODO: Change to selected artist name
+                ShowPotEnglishText_H1(
+                    modifier = Modifier.fillMaxWidth(),
+                    text = "Post Malone",
+                    color = Color.White
+                )
+
+                Spacer(modifier = Modifier.height(1.dp))
+
+                ShowPotKoreanText_H1(
+                    modifier = Modifier.fillMaxWidth(),
+                    text = "구독을 취소하시겠습니까?",
+                    color = Color.White
+                )
+
+                Spacer(modifier = Modifier.height(19.dp))
+
+                ShowPotMainButton(
+                    modifier = Modifier.fillMaxWidth(),
+                    text = "구독 취소하기"
+                ) {
+
+                }
+
+                Spacer(modifier = Modifier.height(54.dp))
+            }
+        }
+
+    }
+
     Column {
         Box(
             modifier = Modifier.padding(horizontal = 16.dp)
@@ -46,11 +102,14 @@ fun SearchedSection(
             item { Spacer(modifier = Modifier.width(4.dp)) }
             searchedArtists.forEach { artist ->
                 item {
-                    ShowPotArtistSubscription(
-                        // TODO: Change to real artist image
+                    ShowPotArtistAlarm(
                         imageUrl = artist.imageURL,
-                        text = artist.englishName
-                    )
+                        text = artist.englishName,
+                        isSubscribed = artist.isSubscribed,
+                    ) {
+                        // TODO: condition
+                        onArtistUnSubscriptionSheetVisibilityChanged(true)
+                    }
                 }
             }
         }

--- a/feature/search/src/main/java/com/alreadyoccupiedseat/search/SearchedSection.kt
+++ b/feature/search/src/main/java/com/alreadyoccupiedseat/search/SearchedSection.kt
@@ -36,6 +36,8 @@ fun SearchedSection(
     isArtistUnSubscriptionSheetVisible: Boolean,
     searchedArtists: List<SubscribedArtist>,
     searchedShows: List<Show>,
+    unSubscribeTargetArtist: String,
+    onUnSubscribeTargetArtistChanged: (String) -> Unit = {},
     onArtistUnSubscriptionSheetVisibilityChanged: (Boolean) -> Unit = {}
 ) {
 
@@ -54,10 +56,9 @@ fun SearchedSection(
 
                 SheetHandler()
 
-                // TODO: Change to selected artist name
                 ShowPotEnglishText_H1(
                     modifier = Modifier.fillMaxWidth(),
-                    text = "Post Malone",
+                    text = unSubscribeTargetArtist,
                     color = Color.White
                 )
 
@@ -107,8 +108,12 @@ fun SearchedSection(
                         text = artist.englishName,
                         isSubscribed = artist.isSubscribed,
                     ) {
-                        // TODO: condition
-                        onArtistUnSubscriptionSheetVisibilityChanged(true)
+                        if (artist.isSubscribed) {
+                            onUnSubscribeTargetArtistChanged(artist.englishName)
+                            onArtistUnSubscriptionSheetVisibilityChanged(true)
+                        } else {
+                            // TODO: subscribe
+                        }
                     }
                 }
             }

--- a/model/src/main/java/com/alreadyoccupiedseat/model/SubscribedArtist.kt
+++ b/model/src/main/java/com/alreadyoccupiedseat/model/SubscribedArtist.kt
@@ -1,0 +1,10 @@
+package com.alreadyoccupiedseat.model
+
+data class SubscribedArtist(
+    val id: String,
+    val imageURL: String,
+    val koreanName: String,
+    val englishName: String,
+    val isSubscribed: Boolean,
+)
+


### PR DESCRIPTION
## 🤘 작업 내용
- 구독 여부 확인 가능한 아티스트 모델 추가 및 적용
- 구독 여부를 확인하여 아티스트에 다른 아이콘 및 커버 색상을 적용시킴
- 구독한 아티스트를 클릭하면 구독 해제 바텀시트를 보여줌

## 📋 변경된 내용
- 검색된 화면에 구독 여부 확인 가능한 아티스트 모델을 적용

## 💻 동작 화면
![sub](https://github.com/user-attachments/assets/b67e6caf-a0c9-4700-b55a-90fa9b6c7dcc)


## 📌 비고
- 영상에서는 구독이 안되어있는 AJR을 눌렀을 때, 바텀시트가 올라오고 Post Malone으로 고정되어있지만 수정함
