### PR TITLE
관심 공연 API 연동 

### DIFF
--- a/app/src/main/java/com/alreadyoccupiedseat/showpot/ui/AppScreen.kt
+++ b/app/src/main/java/com/alreadyoccupiedseat/showpot/ui/AppScreen.kt
@@ -210,7 +210,12 @@ fun AppScreenContent(
             }
 
             composable(Screen.MyFavoriteShows.route) {
-                MyFavoriteShowScreen(navController)
+                MyFavoriteShowScreen(
+                    navController = navController,
+                    onShowClicked = {
+                        navController.navigate(Screen.ShowDetail.route.replace("{showId}", it))
+                    }
+                )
             }
 
             composable(Screen.EntireShowList.route) {

--- a/core/data/src/main/java/com/alreadyoccupiedseat/data/show/ShowDataSource.kt
+++ b/core/data/src/main/java/com/alreadyoccupiedseat/data/show/ShowDataSource.kt
@@ -2,6 +2,7 @@ package com.alreadyoccupiedseat.data.show
 
 import com.alreadyoccupiedseat.model.SearchedShow
 import com.alreadyoccupiedseat.model.show.Data
+import com.alreadyoccupiedseat.model.show.InterestedData
 import com.alreadyoccupiedseat.model.show.ShowDetail
 
 interface ShowDataSource {
@@ -11,6 +12,10 @@ interface ShowDataSource {
         onlyOpenSchedule: Boolean,
         size: Int
     ): List<Data>
+
+    suspend fun getInterestedShowList(
+        size: Int
+    ): List<InterestedData>
 
     suspend fun searchShows(
         cursorId: String? = null,

--- a/core/data/src/main/java/com/alreadyoccupiedseat/data/show/ShowDataSourceImpl.kt
+++ b/core/data/src/main/java/com/alreadyoccupiedseat/data/show/ShowDataSourceImpl.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.provider.Settings
 import com.alreadyoccupiedseat.model.SearchedShow
 import com.alreadyoccupiedseat.model.show.Data
+import com.alreadyoccupiedseat.model.show.InterestedData
 import com.alreadyoccupiedseat.model.show.ShowDetail
 import com.alreadyoccupiedseat.network.ShowService
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -26,6 +27,10 @@ class ShowDataSourceImpl @Inject constructor(
             onlyOpenSchedule = onlyOpenSchedule,
             size = size
         ).body()?.data ?: emptyList()
+    }
+
+override suspend fun getInterestedShowList(size: Int): List<InterestedData> {
+        return showService.getInterestedShowList(size).body()?.data ?: emptyList()
     }
 
     override suspend fun searchShows(

--- a/core/data/src/main/java/com/alreadyoccupiedseat/data/show/ShowRepository.kt
+++ b/core/data/src/main/java/com/alreadyoccupiedseat/data/show/ShowRepository.kt
@@ -2,6 +2,7 @@ package com.alreadyoccupiedseat.data.show
 
 import com.alreadyoccupiedseat.model.SearchedShow
 import com.alreadyoccupiedseat.model.show.Data
+import com.alreadyoccupiedseat.model.show.InterestedData
 import com.alreadyoccupiedseat.model.show.ShowDetail
 
 interface ShowRepository {
@@ -10,6 +11,10 @@ interface ShowRepository {
         onlyOpenSchedule: Boolean,
         size: Int
     ): List<Data>
+
+    suspend fun getInterestedShowList(
+        size: Int
+    ): List<InterestedData>
 
     suspend fun searchShows(
         cursorId: String? = null,

--- a/core/data/src/main/java/com/alreadyoccupiedseat/data/show/ShowRepositoryImpl.kt
+++ b/core/data/src/main/java/com/alreadyoccupiedseat/data/show/ShowRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.alreadyoccupiedseat.data.show
 
 import com.alreadyoccupiedseat.model.SearchedShow
 import com.alreadyoccupiedseat.model.show.Data
+import com.alreadyoccupiedseat.model.show.InterestedData
 import com.alreadyoccupiedseat.model.show.ShowDetail
 import javax.inject.Inject
 
@@ -20,6 +21,10 @@ class ShowRepositoryImpl @Inject constructor(
             onlyOpenSchedule = onlyOpenSchedule,
             size = size
         )
+    }
+
+    override suspend fun getInterestedShowList(size: Int): List<InterestedData> {
+        return showDataSource.getInterestedShowList(size)
     }
 
     override suspend fun searchShows(

--- a/core/network/src/main/java/com/alreadyoccupiedseat/network/ShowService.kt
+++ b/core/network/src/main/java/com/alreadyoccupiedseat/network/ShowService.kt
@@ -2,6 +2,7 @@ package com.alreadyoccupiedseat.network
 
 import com.alreadyoccupiedseat.model.PagingData
 import com.alreadyoccupiedseat.model.SearchedShow
+import com.alreadyoccupiedseat.model.show.InterestedData
 import com.alreadyoccupiedseat.model.show.RegisterInterestResponse
 import com.alreadyoccupiedseat.model.show.ShowDetail
 import com.alreadyoccupiedseat.model.show.Shows
@@ -20,6 +21,11 @@ interface ShowService {
         @Query("onlyOpenSchedule") onlyOpenSchedule: Boolean,
         @Query("size") size: Int,
     ): Response<Shows>
+
+    @GET("api/v1/shows/interests")
+    suspend fun getInterestedShowList(
+        @Query("size") size: Int
+    ): Response<PagingData<InterestedData>>
 
     @GET("api/v1/shows/search")
     suspend fun searchShows(

--- a/feature/account/src/main/java/com/alreadyoccupiedseat/account/AccountViewModel.kt
+++ b/feature/account/src/main/java/com/alreadyoccupiedseat/account/AccountViewModel.kt
@@ -33,6 +33,7 @@ class AccountViewModel @Inject constructor(
 
     private fun getFcmToken() {
         viewModelScope.launch {
+            Log.i("AccountViewModel", "getAccessToken: ${accountDataStore.getAccessToken()}")
             Log.i("AccountViewModel", "getFcmToken: ${accountDataStore.getFcmToken()}")
         }
     }

--- a/feature/myfavorite-show/build.gradle.kts
+++ b/feature/myfavorite-show/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
     //
     implementation(project(":core:designsystem"))
     implementation(project(":core:common"))
+    implementation(project(":core:data"))
     implementation(project(":model"))
     //
     implementation(libs.androidx.core.ktx)

--- a/feature/myfavorite-show/src/main/java/com/alreadyoccupiedseat/myfavorite_show/MyFavoriteShowScreen.kt
+++ b/feature/myfavorite-show/src/main/java/com/alreadyoccupiedseat/myfavorite_show/MyFavoriteShowScreen.kt
@@ -81,9 +81,52 @@ private fun MyFavoriteShowScreenContent(
                     .padding(top = 12.dp)
                     .padding(it),
             ) {
-                if (state.showList.isEmpty()) {
+                if (state.interestedShowList.isEmpty()) {
                     item { MyFavoriteEmpty() }
                 } else {
+                    itemsIndexed(state.interestedShowList) { index, item ->
+                        ShowInfo(
+                            modifier = Modifier
+                                .padding(horizontal = 16.dp)
+                                .clickable {
+                                    // TODO 공연 상세 페이지 이동
+                                },
+                            imageUrl = item.posterImageURL,
+                            showTitle = item.title,
+                            dateInfo =item.startAt,
+                            locationInfo = item.location,
+                            icon = {
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    horizontalArrangement = Arrangement.Center,
+                                    modifier = Modifier
+                                        .clickable {
+                                            onDeletedMyFavoriteShow(item.id)
+                                        }
+                                        .background(ShowpotColor.Gray500)
+
+                                ) {
+                                    Icon(
+                                        modifier = Modifier
+                                            .padding(start = 5.dp)
+                                            .padding(vertical = 8.dp),
+                                        painter = painterResource(R.drawable.ic_delete_24),
+                                        contentDescription = null,
+                                        tint = ShowpotColor.Gray300
+                                    )
+
+                                    ShowPotKoreanText_B2_Regular(
+                                        modifier = Modifier
+                                            .padding(vertical = 6.5.dp)
+                                            .padding(end = 10.dp),
+                                        text = stringResource(R.string.delete),
+                                        color = ShowpotColor.White,
+                                    )
+                                }
+                            }
+                        )
+                    }
+
                     itemsIndexed(state.showList) { index, show ->
                         ShowInfo(
                             modifier = Modifier
@@ -135,7 +178,7 @@ private fun MyFavoriteShowScreenContent(
 }
 
 @Composable
-fun MyFavoriteEmpty(modifier: Modifier = Modifier) {
+fun MyFavoriteEmpty() {
     Column(
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally,

--- a/feature/myfavorite-show/src/main/java/com/alreadyoccupiedseat/myfavorite_show/MyFavoriteShowScreen.kt
+++ b/feature/myfavorite-show/src/main/java/com/alreadyoccupiedseat/myfavorite_show/MyFavoriteShowScreen.kt
@@ -36,12 +36,16 @@ import com.alreadyoccupiedseat.designsystem.typo.korean.ShowPotKoreanText_B2_Reg
 @Composable
 fun MyFavoriteShowScreenPreview(modifier: Modifier = Modifier) {
     val navController = rememberNavController()
-    MyFavoriteShowScreen(navController)
+    MyFavoriteShowScreen(
+        navController = navController,
+        onShowClicked = {}
+        )
 }
 
 @Composable
 fun MyFavoriteShowScreen(
     navController: NavController,
+    onShowClicked: (String) -> Unit,
 ) {
     val viewModel = hiltViewModel<MyFavoriteShowViewModel>()
     val state = viewModel.state.collectAsState()
@@ -50,6 +54,9 @@ fun MyFavoriteShowScreen(
         modifier = Modifier,
         onBackClicked = {
             navController.popBackStack()
+        },
+        onShowClicked = {
+            onShowClicked(it)
         },
         onDeletedMyFavoriteShow = {
             viewModel.deleteMyFavoriteShow(it)
@@ -65,6 +72,7 @@ private fun MyFavoriteShowScreenContent(
     state: MyFavoriteShowState,
     modifier: Modifier,
     onBackClicked: () -> Unit,
+    onShowClicked: (String) -> Unit,
     onDeletedMyFavoriteShow: (showId) -> Unit,
 ) {
 
@@ -89,7 +97,7 @@ private fun MyFavoriteShowScreenContent(
                             modifier = Modifier
                                 .padding(horizontal = 16.dp)
                                 .clickable {
-                                    // TODO 공연 상세 페이지 이동
+                                    onShowClicked(item.id)
                                 },
                             imageUrl = item.posterImageURL,
                             showTitle = item.title,

--- a/feature/myfavorite-show/src/main/java/com/alreadyoccupiedseat/myfavorite_show/MyFavoriteShowViewModel.kt
+++ b/feature/myfavorite-show/src/main/java/com/alreadyoccupiedseat/myfavorite_show/MyFavoriteShowViewModel.kt
@@ -2,9 +2,11 @@ package com.alreadyoccupiedseat.myfavorite_show
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.alreadyoccupiedseat.data.show.ShowRepository
 import com.alreadyoccupiedseat.model.Artist
 import com.alreadyoccupiedseat.model.Genre
 import com.alreadyoccupiedseat.model.Show
+import com.alreadyoccupiedseat.model.show.InterestedData
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -13,66 +15,31 @@ import javax.inject.Inject
 
 data class MyFavoriteShowState(
     val showList: List<Show> = emptyList(),
+    val interestedShowList: List<InterestedData> = emptyList()
 )
 
 @HiltViewModel
-class MyFavoriteShowViewModel @Inject constructor() : ViewModel() {
+class MyFavoriteShowViewModel @Inject constructor(
+    private val showRepository: ShowRepository
+) : ViewModel() {
 
-    private val _state = MutableStateFlow<MyFavoriteShowState>(MyFavoriteShowState())
+    private val _state = MutableStateFlow(MyFavoriteShowState())
     val state = _state
 
     init {
-        loadShowsWithDelay()
+        getInterestedShow()
     }
 
-    private fun loadShowsWithDelay() {
+    /** 관심 공연 ***/
+    private fun getInterestedShow() {
         viewModelScope.launch {
-            // TODO RealData
-            delay(3000)
-
-            _state.value = _state.value.copy(showList =
-            (1..10).map { index ->
-                val genres = listOf(
-                    "Rock",
-                    "Band",
-                    "EDM",
-                    "Classic",
-                    "Hiphop",
-                    "House",
-                    "Opera",
-                    "Pop",
-                    "Rnb",
-                    "Musical",
-                    "Metal",
-                    "Jpop",
-                    "Jazz"
+            showRepository.getInterestedShowList(
+                size = 100
+            ).let {
+                _state.value = _state.value.copy(
+                    interestedShowList = it
                 )
-                val genreName = genres[(index - 1) % genres.size]
-                val posterImageURL = if (index % 2 != 0) {
-                    "https://www.dailypop.kr/news/photo/201509/12537_8555_1158.JPG"
-                } else {
-                    "https://cdnimage.dailian.co.kr/news/201502/news_1423016119_486190_m_1.jpg"
-                }
-
-                Show(
-                    artist = Artist(
-                        id = index.toString(),
-                        imageURL = "https://example.com/artist$index.jpg",
-                        koreanName = "Artist $index",
-                        englishName = "Artist $index"
-                    ),
-                    genre = Genre(
-                        id = index.toString(),
-                        name = genreName,
-                        isSubscribed = index % 2 == 0
-                    ),
-                    id = index.toString(),
-                    name = "Concert $index",
-                    posterImageURL = posterImageURL,
-                    ticketingAndShowInfo = listOf(/* ... */)
-                )
-            })
-
+            }
         }
     }
 

--- a/model/src/main/java/com/alreadyoccupiedseat/model/show/InterestedData.kt
+++ b/model/src/main/java/com/alreadyoccupiedseat/model/show/InterestedData.kt
@@ -1,0 +1,12 @@
+package com.alreadyoccupiedseat.model.show
+
+data class InterestedData (
+    val id: String,
+    val title: String,
+    val startAt: String,
+    val endAt: String,
+    val interestShowId: String,
+    val interestedAt: String,
+    val location: String,
+    val posterImageURL: String
+)


### PR DESCRIPTION
## 🤘 작업 내용
- 관심 공연 API 연동

## 📋 변경된 내용
- 관심 공연 API 연동 리스트 표기 

## 💻 동작 화면 
![Aug-30-2024 00-45-14](https://github.com/user-attachments/assets/925904b4-bf96-4b52-8eaa-d5a345564b74)


## 📌 비고
- 관심 공연 등록 api가 없어, 우선 서버에 요청해서 더미 데이터로 표기했습니다.
