### PR TITLE
아티스트 구독 화면 에러들 수정(로그인 처리 이슈, 구독 전 스낵바가 등장하던 이슈)

### DIFF
--- a/feature/subscription-artist/src/main/java/com/alreadyoccupiedseat/subscription_artist/SubscriptionArtistScreen.kt
+++ b/feature/subscription-artist/src/main/java/com/alreadyoccupiedseat/subscription_artist/SubscriptionArtistScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -57,39 +58,52 @@ fun SubscriptionArtistScreen(
     val state = viewModel.state.collectAsState()
     val event = viewModel.event.collectAsState()
 
+    val coroutineScope = rememberCoroutineScope()
+    val snackbarHostState = remember { SnackbarHostState() }
+
     when (event.value) {
         SubscriptionArtistScreenEvent.Idle -> {
-            SubscriptionArtistScreenContent(
-                state = state.value,
-                onBackClicked = {
-                    navController.popBackStack()
-                },
-                onSheetStateChanged = { isVisible ->
-                    viewModel.setSheetVisible(isVisible)
-                },
-                onSubscribeButtonClicked = {
-                    viewModel.subscribeArtists()
-                },
-                onArtistClicked = {
-                    viewModel.selectArtist(it)
-                },
-                checkIsSelected = {
-                    viewModel.isSelected(it)
-                },
-                onLoginRequested = {
-                    viewModel.setSheetVisible(false)
-                    onLoginRequested()
-                }
-            )
         }
 
+        SubscriptionArtistScreenEvent.SubscribeArtistsSuccess -> {
+            LaunchedEffect(snackbarHostState) {
+                coroutineScope.launch {
+                    snackbarHostState.showSnackbar("구독 설정이 완료되었습니다")
+                }
+            }
+        }
     }
+
+    SubscriptionArtistScreenContent(
+        state = state.value,
+        snackbarHostState = snackbarHostState,
+        onBackClicked = {
+            navController.popBackStack()
+        },
+        onSheetStateChanged = { isVisible ->
+            viewModel.setSheetVisible(isVisible)
+        },
+        onSubscribeButtonClicked = {
+            viewModel.subscribeArtists()
+        },
+        onArtistClicked = {
+            viewModel.selectArtist(it)
+        },
+        checkIsSelected = {
+            viewModel.isSelected(it)
+        },
+        onLoginRequested = {
+            viewModel.setSheetVisible(false)
+            onLoginRequested()
+        }
+    )
 }
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun SubscriptionArtistScreenContent(
     state: SubscriptionArtistScreenState,
+    snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
     onBackClicked: () -> Unit,
     onSheetStateChanged: (Boolean) -> Unit = {},
     onSubscribeButtonClicked: () -> Unit = {},
@@ -99,7 +113,6 @@ fun SubscriptionArtistScreenContent(
 ) {
 
     val scope = rememberCoroutineScope()
-    val snackbarHostState = remember { SnackbarHostState() }
 
     if (state.isSheetVisible) {
 
@@ -260,7 +273,6 @@ fun SubscriptionArtistScreenContent(
                         ) {
                             scope.launch {
                                 onSubscribeButtonClicked()
-                                snackbarHostState.showSnackbar("구독 설정이 완료되었습니다")
                             }
                         }
                     }

--- a/feature/subscription-artist/src/main/java/com/alreadyoccupiedseat/subscription_artist/SubscriptionArtistScreen.kt
+++ b/feature/subscription-artist/src/main/java/com/alreadyoccupiedseat/subscription_artist/SubscriptionArtistScreen.kt
@@ -76,7 +76,10 @@ fun SubscriptionArtistScreen(
                 checkIsSelected = {
                     viewModel.isSelected(it)
                 },
-                onLoginRequested = onLoginRequested
+                onLoginRequested = {
+                    viewModel.setSheetVisible(false)
+                    onLoginRequested()
+                }
             )
         }
 

--- a/feature/subscription-artist/src/main/java/com/alreadyoccupiedseat/subscription_artist/SubscriptionArtistViewModel.kt
+++ b/feature/subscription-artist/src/main/java/com/alreadyoccupiedseat/subscription_artist/SubscriptionArtistViewModel.kt
@@ -12,6 +12,8 @@ import javax.inject.Inject
 
 sealed interface SubscriptionArtistScreenEvent {
     data object Idle : SubscriptionArtistScreenEvent
+
+    data object SubscribeArtistsSuccess : SubscriptionArtistScreenEvent
 }
 
 data class SubscriptionArtistScreenState(
@@ -42,7 +44,7 @@ class SubscriptionArtistViewModel @Inject constructor(
     private var _state = MutableStateFlow(SubscriptionArtistScreenState())
     val state = _state
 
-    val event = MutableStateFlow(SubscriptionArtistScreenEvent.Idle)
+    val event = MutableStateFlow<SubscriptionArtistScreenEvent>(SubscriptionArtistScreenEvent.Idle)
 
     fun subscribeArtists() {
         viewModelScope.launch {
@@ -52,6 +54,7 @@ class SubscriptionArtistViewModel @Inject constructor(
                 selectedArtists = emptyList(),
                 unsubscribedArtists = state.value.unsubscribedArtists.filter { it.id !in subscribedArtistsIds },
             )
+            event.emit(SubscriptionArtistScreenEvent.SubscribeArtistsSuccess)
         }
     }
 

--- a/feature/subscription-artist/src/main/java/com/alreadyoccupiedseat/subscription_artist/SubscriptionArtistViewModel.kt
+++ b/feature/subscription-artist/src/main/java/com/alreadyoccupiedseat/subscription_artist/SubscriptionArtistViewModel.kt
@@ -31,8 +31,10 @@ class SubscriptionArtistViewModel @Inject constructor(
     init {
         getUnsubscribedArtists()
         viewModelScope.launch {
-            accountDataStore.getAccessToken()?.let {
-                _state.value = _state.value.copy(isLoggedIn = true)
+            accountDataStore.getAccessTokenFlow().collect {
+                _state.value = _state.value.copy(
+                    isLoggedIn = it?.isNotEmpty() ?: false,
+                )
             }
         }
     }


### PR DESCRIPTION
## 🤘 작업 내용
- 아티스트 구독 화면에서 로그인 후, 로그인 적용이 안되는 이슈 해결
- 실제 구독이 완료되기 전 스낵바가 생성되는 이슈 해결

## 📋 변경된 내용
- 아티스트 구독 화면에서 로그인 후, 로그인 적용이 안되는 이슈 해결
- 실제 구독이 완료되기 전 스낵바가 생성되는 이슈 해결

## 💻 동작 화면
![subscription_artist_error](https://github.com/user-attachments/assets/fe7d6d4f-b239-4604-a66f-3a8719209e63)

## 📌 비고
- 비고 없음
