### PR TITLE
계정 화면에서 실제 닉네임을 보여주도록 Api 연결, 회원 탈퇴 기능 Api 연동회원 탈퇴 기능 추가

### DIFF
--- a/core/data/src/main/java/com/alreadyoccupiedseat/data/login/LoginRepository.kt
+++ b/core/data/src/main/java/com/alreadyoccupiedseat/data/login/LoginRepository.kt
@@ -13,4 +13,6 @@ interface LoginRepository {
 
     suspend fun getProfile(): Result<ProfileResponse>
 
+    suspend fun requestWithDraw(): Result<Unit>
+
 }

--- a/core/data/src/main/java/com/alreadyoccupiedseat/data/login/LoginRepositoryImpl.kt
+++ b/core/data/src/main/java/com/alreadyoccupiedseat/data/login/LoginRepositoryImpl.kt
@@ -32,4 +32,8 @@ class LoginRepositoryImpl @Inject constructor(
         return remoteLoginDataSource.getProfile()
     }
 
+    override suspend fun requestWithDraw(): Result<Unit> {
+        return remoteLoginDataSource.requestWithDraw()
+    }
+
 }

--- a/core/data/src/main/java/com/alreadyoccupiedseat/data/login/remote/RemoteLoginDataSource.kt
+++ b/core/data/src/main/java/com/alreadyoccupiedseat/data/login/remote/RemoteLoginDataSource.kt
@@ -9,4 +9,6 @@ interface RemoteLoginDataSource {
     suspend fun reIssueToken(): Result<Unit>
 
     suspend fun getProfile(): Result<ProfileResponse>
+
+    suspend fun requestWithDraw(): Result<Unit>
 }

--- a/core/data/src/main/java/com/alreadyoccupiedseat/data/login/remote/RemoteLoginDataSourceImpl.kt
+++ b/core/data/src/main/java/com/alreadyoccupiedseat/data/login/remote/RemoteLoginDataSourceImpl.kt
@@ -5,6 +5,7 @@ import com.alreadyoccupiedseat.datastore.AccountDataStore
 import com.alreadyoccupiedseat.model.login.LoginRequest
 import com.alreadyoccupiedseat.model.login.ProfileResponse
 import com.alreadyoccupiedseat.model.login.TokenReIssueRequest
+import com.alreadyoccupiedseat.model.temp.LogOutAndWithDrawRequest
 import com.alreadyoccupiedseat.network.LoginService
 import javax.inject.Inject
 
@@ -47,6 +48,14 @@ class RemoteLoginDataSourceImpl @Inject constructor(
     override suspend fun getProfile(): Result<ProfileResponse> {
         return runCatching {
             loginService.getProfile().body() ?: throw Exception("Profile is null")
+        }
+    }
+
+    override suspend fun requestWithDraw(): Result<Unit> {
+        return runCatching {
+            loginService.requestWithDraw(
+                LogOutAndWithDrawRequest(accountDataStore.getAccessToken() ?: String.EMPTY)
+            ).body()
         }
     }
 }

--- a/core/network/src/main/java/com/alreadyoccupiedseat/network/LoginService.kt
+++ b/core/network/src/main/java/com/alreadyoccupiedseat/network/LoginService.kt
@@ -4,6 +4,7 @@ import com.alreadyoccupiedseat.model.login.LoginResponse
 import com.alreadyoccupiedseat.model.login.LoginRequest
 import com.alreadyoccupiedseat.model.login.ProfileResponse
 import com.alreadyoccupiedseat.model.login.TokenReIssueRequest
+import com.alreadyoccupiedseat.model.temp.LogOutAndWithDrawRequest
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.GET
@@ -23,4 +24,9 @@ interface LoginService {
 
     @GET("api/v1/users/profile")
     suspend fun getProfile(): Response<ProfileResponse>
+
+    @POST("/api/v1/users/withdrawal")
+    suspend fun requestWithDraw(
+        @Body withDrawRequest: LogOutAndWithDrawRequest
+    ): Response<Unit>
 }

--- a/feature/account/build.gradle.kts
+++ b/feature/account/build.gradle.kts
@@ -39,6 +39,7 @@ dependencies {
     implementation(project(":core:designsystem"))
     implementation(project(":core:common"))
     implementation(project(":core:datastore"))
+    implementation(project(":core:data"))
     implementation(project(":model"))
     //
     implementation(libs.androidx.core.ktx)

--- a/feature/account/src/main/java/com/alreadyoccupiedseat/account/AccountScreen.kt
+++ b/feature/account/src/main/java/com/alreadyoccupiedseat/account/AccountScreen.kt
@@ -28,6 +28,7 @@ import com.alreadyoccupiedseat.designsystem.ShowpotColor
 import com.alreadyoccupiedseat.designsystem.component.IconMenuWithCount
 import com.alreadyoccupiedseat.designsystem.typo.korean.ShowPotKoreanText_B1_Regular
 import com.alreadyoccupiedseat.designsystem.typo.korean.ShowPotKoreanText_H2
+import kotlinx.coroutines.delay
 
 @Preview
 @Composable
@@ -52,12 +53,23 @@ fun AccountScreen(
     when (event.value) {
         AccountScreenEvent.Idle -> {}
         AccountScreenEvent.AccountLogout -> {
-            Toast.makeText(context, "로그아웃 되었습니다.", Toast.LENGTH_SHORT).show()
-            viewModel.clear()
+            // TODO: 화면 프레임 스킵되는 이슈 찾아서 해결 필요
+            LaunchedEffect(true) {
+                delay(300L)
+                viewModel.clear()
+                Toast.makeText(context, "로그아웃 되었습니다.", Toast.LENGTH_SHORT).show()
+                navController.popBackStack()
+            }
         }
 
         AccountScreenEvent.Withdrawal -> {
-            Toast.makeText(context, "회원 탈퇴가 요청되었습니다.", Toast.LENGTH_SHORT).show()
+            // TODO: 화면 프레임 스킵되는 이슈 찾아서 해결 필요
+            LaunchedEffect(true) {
+                delay(300L)
+                viewModel.clear()
+                Toast.makeText(context, "회원 탈퇴가 성공하였습니다.", Toast.LENGTH_SHORT).show()
+                navController.popBackStack()
+            }
         }
     }
     AccountScreenContent(

--- a/feature/account/src/main/java/com/alreadyoccupiedseat/account/AccountScreen.kt
+++ b/feature/account/src/main/java/com/alreadyoccupiedseat/account/AccountScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -40,19 +41,27 @@ fun AccountScreen(
     navController: NavController,
 ) {
     val viewModel = hiltViewModel<AccountViewModel>()
+    val state = viewModel.state.collectAsState()
     val event = viewModel.event.collectAsState(AccountScreenEvent.Idle)
     val context = LocalContext.current
+
+    LaunchedEffect(true) {
+        viewModel.getNickName()
+    }
+
     when (event.value) {
         AccountScreenEvent.Idle -> {}
         AccountScreenEvent.AccountLogout -> {
             Toast.makeText(context, "로그아웃 되었습니다.", Toast.LENGTH_SHORT).show()
             viewModel.clear()
         }
+
         AccountScreenEvent.Withdrawal -> {
             Toast.makeText(context, "회원 탈퇴가 요청되었습니다.", Toast.LENGTH_SHORT).show()
         }
     }
     AccountScreenContent(
+        state = state.value,
         onBackClicked = {
             navController.popBackStack()
         },
@@ -68,6 +77,7 @@ fun AccountScreen(
 
 @Composable
 private fun AccountScreenContent(
+    state: AccountScreenState,
     onBackClicked: () -> Unit,
     onAccountLogOut: () -> Unit,
     onWithdrawal: () -> Unit,
@@ -96,7 +106,7 @@ private fun AccountScreenContent(
                         ShowPotKoreanText_H2(
                             modifier = Modifier
                                 .weight(1f),
-                            text = "춤추는 고래", // TODO NickName
+                            text = state.nickName,
                             color = ShowpotColor.Gray100
                         )
                         ShowPotKoreanText_B1_Regular(

--- a/feature/account/src/main/java/com/alreadyoccupiedseat/account/AccountViewModel.kt
+++ b/feature/account/src/main/java/com/alreadyoccupiedseat/account/AccountViewModel.kt
@@ -3,9 +3,12 @@ package com.alreadyoccupiedseat.account
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.alreadyoccupiedseat.core.extension.EMPTY
+import com.alreadyoccupiedseat.data.login.LoginRepository
 import com.alreadyoccupiedseat.datastore.AccountDataStore
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -17,10 +20,18 @@ sealed interface AccountScreenEvent {
 
 }
 
+data class AccountScreenState(
+    val nickName: String = String.EMPTY,
+)
+
 @HiltViewModel
 class AccountViewModel @Inject constructor(
     private val accountDataStore: AccountDataStore,
+    private val loginRepository: LoginRepository
 ): ViewModel() {
+
+    private val _state = MutableStateFlow<AccountScreenState>(AccountScreenState())
+    val state = _state
 
     private var _event = MutableSharedFlow<AccountScreenEvent>()
     val event = _event
@@ -51,7 +62,15 @@ class AccountViewModel @Inject constructor(
 
     fun withdrawal() {
         viewModelScope.launch {
-            _event.emit(AccountScreenEvent.Withdrawal)
+
+        }
+    }
+
+    fun getNickName() {
+        viewModelScope.launch {
+            loginRepository.getProfile().onSuccess {
+                _state.value = state.value.copy(nickName = it.nickname)
+            }
         }
     }
 

--- a/feature/account/src/main/java/com/alreadyoccupiedseat/account/AccountViewModel.kt
+++ b/feature/account/src/main/java/com/alreadyoccupiedseat/account/AccountViewModel.kt
@@ -62,7 +62,9 @@ class AccountViewModel @Inject constructor(
 
     fun withdrawal() {
         viewModelScope.launch {
-
+            loginRepository.requestWithDraw().onSuccess {
+                _event.emit(AccountScreenEvent.Withdrawal)
+            }
         }
     }
 

--- a/model/src/main/java/com/alreadyoccupiedseat/model/temp/LogOutAndWithDrawRequest.kt
+++ b/model/src/main/java/com/alreadyoccupiedseat/model/temp/LogOutAndWithDrawRequest.kt
@@ -1,0 +1,5 @@
+package com.alreadyoccupiedseat.model.temp
+
+data class LogOutAndWithDrawRequest(
+    val accessToken: String
+)


### PR DESCRIPTION
## 🤘 작업 내용
- 회원 탈퇴 기능 Api 연동
- 계정 화면에서 실제 닉네임을 보여주도록 Api 연결

## 📋 변경된 내용
- 변경된 내용을 작성해주세요.

## 💻 동작 화면
![withdraw](https://github.com/user-attachments/assets/ad21ed89-7c34-4c60-a357-c451b6ec5414)

## 📌 비고
- 비고 없음
