### PR TITLE
아티스트 구독 화면에서 버튼이 없을 때도 그라데이션이 적용되도록 변경

### DIFF
--- a/feature/subscription-artist/src/main/java/com/alreadyoccupiedseat/subscription_artist/SubscriptionArtistScreen.kt
+++ b/feature/subscription-artist/src/main/java/com/alreadyoccupiedseat/subscription_artist/SubscriptionArtistScreen.kt
@@ -241,7 +241,20 @@ fun SubscriptionArtistScreenContent(
 
                 }
 
-                // Todo: Visibility depends on whether artists are selected
+                Spacer(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(56.dp)
+                        .background(
+                            brush = Brush.verticalGradient(
+                                colors = listOf(
+                                    ShowpotColor.Gray700.copy(alpha = 0f),
+                                    ShowpotColor.Gray700
+                                ),
+                            )
+                        ).align(Alignment.BottomCenter)
+                )
+
                 this@Column.AnimatedVisibility(
                     visible = state.selectedArtists.isNotEmpty(),
                     enter = slideInVertically(
@@ -255,14 +268,6 @@ fun SubscriptionArtistScreenContent(
                         modifier = Modifier
                             .padding(top = 4.dp)
                             .fillMaxWidth()
-                            .background(
-                                brush = Brush.verticalGradient(
-                                    colors = listOf(
-                                        ShowpotColor.Gray700.copy(alpha = 0f),
-                                        ShowpotColor.Gray700
-                                    ),
-                                )
-                            )
                             .padding(bottom = 54.dp),
                     ) {
                         ShowPotMainButton(


### PR DESCRIPTION
## 🤘 작업 내용
- 아티스트 구독 화면에서 버튼이 없을 때도 그라데이션이 적용되도록 변경

## 📋 변경된 내용
- 아티스트 구독 화면에서 버튼이 없을 때도 그라데이션이 적용되도록 변경

## 💻 동작 화면
- 동작 화면 없음

## 📌 비고
- 비고 없음
