### PR TITLE
카운트가 있는 아이콘 메뉴의 카운트 비활성화, 티켓팅 종료 공연 비활성화 - MVP 이후 작업

### DIFF
--- a/core/designsystem/src/main/java/com/alreadyoccupiedseat/designsystem/component/IconMenuWithCount.kt
+++ b/core/designsystem/src/main/java/com/alreadyoccupiedseat/designsystem/component/IconMenuWithCount.kt
@@ -71,12 +71,13 @@ fun IconMenuWithCount(
         Row(
             verticalAlignment = Alignment.CenterVertically
         ) {
-            if (count != null) {
-                ShowPotKoreanText_B1_SemiBold(
-                    text = count.toString(),
-                    color = ShowpotColor.Gray100,
-                )
-            }
+            // TODO: after MVP
+//            if (count != null) {
+//                ShowPotKoreanText_B1_SemiBold(
+//                    text = count.toString(),
+//                    color = ShowpotColor.Gray100,
+//                )
+//            }
 
             Icon(
                 painter = painterResource(id = R.drawable.ic_arrow_24_right),

--- a/feature/notification/src/main/java/com/alreadyoccupiedseat/notification/NotificationScreen.kt
+++ b/feature/notification/src/main/java/com/alreadyoccupiedseat/notification/NotificationScreen.kt
@@ -170,15 +170,15 @@ fun NotificationScreenContent(
 
             item { Spacer(Modifier.height(12.dp)) }
             // 티켓팅 종료 공연
-            item {
-                IconMenuWithCount(
-                    firstIcon = painterResource(id = com.alreadyoccupiedseat.designsystem.R.drawable.ic_ticket_close_24), // Todo: Change Icon (?) -> 작아보임
-                    title = stringResource(com.alreadyoccupiedseat.designsystem.R.string.close_ticketing_shows),
-                    count = 5,
-                ) {
-                    onMyFinishedShowClicked()
-                }
-            }
+//            item {
+//                IconMenuWithCount(
+//                    firstIcon = painterResource(id = com.alreadyoccupiedseat.designsystem.R.drawable.ic_ticket_close_24), // Todo: Change Icon (?) -> 작아보임
+//                    title = stringResource(com.alreadyoccupiedseat.designsystem.R.string.close_ticketing_shows),
+//                    count = 5,
+//                ) {
+//                    onMyFinishedShowClicked()
+//                }
+//            }
         }
 
     }


### PR DESCRIPTION
## 🤘 작업 내용
- 카운트가 있는 아이콘 메뉴의 카운트 비활성화
- 티켓팅 종료 공연 비활성화 - MVP 이후 작업

## 📋 변경된 내용
- 변경된 내용을 작성해주세요.

## 💻 동작 화면
- 동작 화면 없음

## 📌 비고
- 비고 없음
