### PR TITLE
티켓 뷰가 터지던 이슈 해결, 공연 이름이 너무 길어지면 줄임말 처리하도록 변경

### DIFF
--- a/feature/notification/src/main/java/com/alreadyoccupiedseat/notification/NotificationScreen.kt
+++ b/feature/notification/src/main/java/com/alreadyoccupiedseat/notification/NotificationScreen.kt
@@ -15,12 +15,12 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.alreadyoccupiedseat.designsystem.ShowpotColor
 import com.alreadyoccupiedseat.designsystem.component.IconMenuWithCount
-import com.alreadyoccupiedseat.designsystem.component.ticketSlider.TicketSlidePager
 import com.alreadyoccupiedseat.designsystem.typo.english.ShowPotEnglishText_H0
 import com.alreadyoccupiedseat.designsystem.typo.korean.ShowPotKoreanText_H0
 import com.alreadyoccupiedseat.designsystem.typo.korean.ShowPotKoreanText_H1
@@ -79,7 +79,8 @@ fun NotificationScreenContent(
     onMyFinishedShowClicked: () -> Unit,
 ) {
 
-    val pagerState = rememberPagerState(pageCount = { state.upcomingTicketingShows.size - 1 })
+    val pagerState = rememberPagerState(pageCount = { state.upcomingTicketingShows.size })
+
     Scaffold(
         containerColor = ShowpotColor.Gray700,
     ) {
@@ -109,7 +110,9 @@ fun NotificationScreenContent(
                     ShowPotEnglishText_H0(
                         text = state.upcomingTicketingShows[pagerState.currentPage].title,
                         modifier = Modifier.padding(horizontal = 16.dp),
-                        color = ShowpotColor.Gray100
+                        color = ShowpotColor.Gray100,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
                     )
                 }
 

--- a/feature/notification/src/main/java/com/alreadyoccupiedseat/notification/NotificationViewModel.kt
+++ b/feature/notification/src/main/java/com/alreadyoccupiedseat/notification/NotificationViewModel.kt
@@ -34,7 +34,8 @@ class NotificationViewModel @Inject constructor(
 
     fun getUpcomingTicketingShows() {
         viewModelScope.launch {
-            val upcomingTicketingShows = showRepository.getAlarmReservedShow(5, "CONTINUED")
+            _state.value = _state.value.copy(upcomingTicketingShows = emptyList())
+            val upcomingTicketingShows = showRepository.getAlarmReservedShow(100, "CONTINUED")
             _state.value = _state.value.copy(upcomingTicketingShows = upcomingTicketingShows)
         }
     }

--- a/feature/notification/src/main/java/com/alreadyoccupiedseat/notification/TicketSlidePagerForAlarmReservedShow.kt
+++ b/feature/notification/src/main/java/com/alreadyoccupiedseat/notification/TicketSlidePagerForAlarmReservedShow.kt
@@ -52,7 +52,7 @@ fun TicketSlidePagerForAlarmReservedShow(
     ) {
         HorizontalPager(
             contentPadding = PaddingValues(horizontal = 66.dp, vertical = 24.dp),
-            beyondBoundsPageCount = 2,
+            beyondBoundsPageCount = 0,
             state = pagerState,
             modifier = Modifier
                 .background(ShowpotColor.Gray700)


### PR DESCRIPTION
## 🤘 작업 내용
- 티켓 뷰가 터지던 이슈 해결
- 공연 이름이 너무 길어지면 줄임말 처리하도록 변경

## 📋 변경된 내용
- 변경된 내용을 작성해주세요.

## 💻 동작 화면
- 동작 화면 없음

## 📌 비고
- 비고 없음
