### PR TITLE
장르/아티스트 구독하기, 구독한 아티스트 화면 TopBar 수정과 빈 화면일 경우 구독하기 화면으로 이동 액션 추가

### DIFF
--- a/app/src/main/java/com/alreadyoccupiedseat/showpot/ui/AppScreen.kt
+++ b/app/src/main/java/com/alreadyoccupiedseat/showpot/ui/AppScreen.kt
@@ -187,7 +187,12 @@ fun AppScreenContent(
             }
 
             composable(Screen.SubscribedArtist.route) {
-                SubscribedArtistScreen(navController)
+                SubscribedArtistScreen(
+                    navController = navController,
+                    onGoToSubscriptionArtist = {
+                        navController.navigate(Screen.SubscriptionArtist.route)
+                    }
+                )
             }
 
             composable(

--- a/core/designsystem/src/main/java/com/alreadyoccupiedseat/designsystem/component/ShowPotAppBar.kt
+++ b/core/designsystem/src/main/java/com/alreadyoccupiedseat/designsystem/component/ShowPotAppBar.kt
@@ -32,7 +32,7 @@ fun ShowPotTopBar(
         ) {
             Row(
                 Modifier
-                    .padding(0.dp)
+                    .padding(top = 12.dp)
                     .height(44.dp)
                     .align(Alignment.CenterStart),
                 verticalAlignment = Alignment.CenterVertically,

--- a/core/designsystem/src/main/java/com/alreadyoccupiedseat/designsystem/component/artist/ShowPotArtistDelete.kt
+++ b/core/designsystem/src/main/java/com/alreadyoccupiedseat/designsystem/component/artist/ShowPotArtistDelete.kt
@@ -11,12 +11,13 @@ import com.alreadyoccupiedseat.designsystem.R
 @Composable
 fun ShowPotArtistDelete(
     modifier: Modifier = Modifier,
+    name: String,
     imageUrl: String,
     onIconClick: () -> Unit,
 ) {
     ShowPotArtist(
         imageUrl = imageUrl,
-        text = "High Flying Birds",
+        text = name,
         content = {
             Image(
                 painter = painterResource(id = R.drawable.ic_circle_delete_40), // Genre 브런치와 합쳐지면 변경 필요

--- a/feature/subscribed-artist/src/main/java/com/alreadyoccupiedseat/subscribed_artist/SubscribedArtistScreen.kt
+++ b/feature/subscribed-artist/src/main/java/com/alreadyoccupiedseat/subscribed_artist/SubscribedArtistScreen.kt
@@ -28,6 +28,7 @@ import com.alreadyoccupiedseat.designsystem.component.button.ShowPotSubButton
 @Composable
 fun SubscribedArtistScreen(
     navController: NavController,
+    onGoToSubscriptionArtist: () -> Unit
 ) {
     val viewModel = hiltViewModel<SubscribedArtistViewModel>()
     val state = viewModel.state.collectAsState()
@@ -36,6 +37,9 @@ fun SubscribedArtistScreen(
         modifier = Modifier,
         onBackClicked = {
             navController.popBackStack()
+        },
+        onGoToSubscriptionArtist = {
+            onGoToSubscriptionArtist()
         },
         onDeletedSubscribedArtist = {
             viewModel.deleteSubscribedArtist(it)
@@ -50,6 +54,7 @@ private fun SubscribedArtistContent(
     state: SubscribedArtistState,
     modifier: Modifier,
     onBackClicked: () -> Unit,
+    onGoToSubscriptionArtist: () -> Unit,
     onDeletedSubscribedArtist: (artistId) -> Unit,
 ) {
 
@@ -65,7 +70,11 @@ private fun SubscribedArtistContent(
                     .padding(it),
             ) {
                 if (state.subscribedArtists.isEmpty()) {
-                    SubscribedArtistEmpty()
+                    SubscribedArtistEmpty(
+                        onGoToSubscriptionArtist = {
+                            onGoToSubscriptionArtist()
+                        }
+                    )
                 }
                 LazyVerticalGrid(
                     modifier = Modifier
@@ -79,6 +88,7 @@ private fun SubscribedArtistContent(
                     // TODO: Real Data
                     items(state.subscribedArtists) { artist ->
                         ShowPotArtistDelete(
+                            name = artist.englishName,
                             imageUrl = artist.imageURL,
                             onIconClick = {
                                 onDeletedSubscribedArtist(artist.id)
@@ -93,7 +103,9 @@ private fun SubscribedArtistContent(
 }
 
 @Composable
-private fun SubscribedArtistEmpty() {
+private fun SubscribedArtistEmpty(
+    onGoToSubscriptionArtist: () -> Unit,
+) {
     Column(
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -113,7 +125,7 @@ private fun SubscribedArtistEmpty() {
             modifier = Modifier.padding(horizontal = 16.dp),
             text = stringResource(id = R.string.action_subscribe_artist),
             onClicked = {
-                // TODO 아티스트 구독 화면 이동
+                onGoToSubscriptionArtist()
             }
         )
     }

--- a/feature/subscribed-artist/src/main/java/com/alreadyoccupiedseat/subscribed_artist/SubscribedArtistScreen.kt
+++ b/feature/subscribed-artist/src/main/java/com/alreadyoccupiedseat/subscribed_artist/SubscribedArtistScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -32,6 +33,11 @@ fun SubscribedArtistScreen(
 ) {
     val viewModel = hiltViewModel<SubscribedArtistViewModel>()
     val state = viewModel.state.collectAsState()
+
+    LaunchedEffect(Unit) {
+        viewModel.getSubscribedArtist()
+    }
+
     SubscribedArtistContent(
         state = state.value,
         modifier = Modifier,

--- a/feature/subscribed-artist/src/main/java/com/alreadyoccupiedseat/subscribed_artist/SubscribedArtistViewModel.kt
+++ b/feature/subscribed-artist/src/main/java/com/alreadyoccupiedseat/subscribed_artist/SubscribedArtistViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.viewModelScope
 import com.alreadyoccupiedseat.data.artist.ArtistRepository
 import com.alreadyoccupiedseat.model.Artist
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -32,11 +31,7 @@ class SubscribedArtistViewModel @Inject constructor(
     private val _event = MutableStateFlow<SubscribedArtistEvent>(SubscribedArtistEvent.Idle)
     val event = _event
 
-    init {
-        loadSubscribedArtist()
-    }
-
-    private fun loadSubscribedArtist() {
+    fun getSubscribedArtist() {
         viewModelScope.launch {
             val result = aristRepository.getSubscribedArtists(
                 size = 100

--- a/feature/subscription-artist/src/main/java/com/alreadyoccupiedseat/subscription_artist/SubscriptionArtistScreen.kt
+++ b/feature/subscription-artist/src/main/java/com/alreadyoccupiedseat/subscription_artist/SubscriptionArtistScreen.kt
@@ -176,30 +176,12 @@ fun SubscriptionArtistScreenContent(
         },
         // TODO: To be a component
         topBar = {
-            Row(
-                modifier = Modifier
-                    .padding(top = 12.dp)
-                    .fillMaxWidth(),
-                verticalAlignment = androidx.compose.ui.Alignment.CenterVertically
-            ) {
-                Spacer(modifier = Modifier.width(6.dp))
-
-                Icon(
-                    painter = painterResource(id = com.alreadyoccupiedseat.designsystem.R.drawable.ic_arrow_36_left),
-                    contentDescription = "back",
-                    tint = Color.White,
-                    modifier = Modifier.clickable {
-                        onBackClicked()
-                    }
-                )
-
-                ShowPotKoreanText_H1(
-                    text = stringResource(R.string.subscribe_artist),
-                    color = ShowpotColor.Gray100,
-                )
-            }
+            SubscriptionArtistTopBar(
+                onBackClicked = {
+                    onBackClicked()
+                }
+            )
         }
-
     ) { innerPadding ->
 
         Column(

--- a/feature/subscription-artist/src/main/java/com/alreadyoccupiedseat/subscription_artist/SubscriptionArtistTopBar.kt
+++ b/feature/subscription-artist/src/main/java/com/alreadyoccupiedseat/subscription_artist/SubscriptionArtistTopBar.kt
@@ -1,4 +1,4 @@
-package com.alreadyoccupiedseat.subscribed_artist
+package com.alreadyoccupiedseat.subscription_artist
 
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Icon
@@ -14,7 +14,7 @@ import com.alreadyoccupiedseat.designsystem.component.ShowPotTopBar
 import com.alreadyoccupiedseat.designsystem.typo.korean.ShowPotKoreanText_H1
 
 @Composable
-internal fun SubscribedArtistTopBar(
+fun SubscriptionArtistTopBar(
     onBackClicked: () -> Unit,
 ) {
     ShowPotTopBar(
@@ -32,8 +32,8 @@ internal fun SubscribedArtistTopBar(
         },
         title = {
             ShowPotKoreanText_H1(
-                text = stringResource(id = R.string.subscribed_artists),
-                color = ShowpotColor.Gray300,
+                text = stringResource(com.alreadyoccupiedseat.subscription_artist.R.string.subscribe_artist),
+                color = ShowpotColor.Gray100,
                 modifier = Modifier
                     .padding(start = 4.dp)
                     .padding(vertical = 7.dp)

--- a/feature/subscription-genre/src/main/java/com/alreadyoccupiedseat/subscription_genre/SubscriptionGenreTopBar.kt
+++ b/feature/subscription-genre/src/main/java/com/alreadyoccupiedseat/subscription_genre/SubscriptionGenreTopBar.kt
@@ -17,10 +17,13 @@ import com.alreadyoccupiedseat.designsystem.typo.korean.ShowPotKoreanText_H1
 fun SubscriptionTopBar(onBackClicked: () -> Unit) {
     ShowPotTopBar(
         navigationIcon = {
-            IconButton(onClick = onBackClicked) {
+            IconButton(onClick = { onBackClicked() }) {
                 Icon(
-                    modifier = Modifier.padding(1.dp),
-                    painter = painterResource(R.drawable.ic_arrow_36_left),
+                    tint = ShowpotColor.White,
+                    modifier = Modifier
+                        .padding(vertical = 4.dp)
+                        .padding(start = 6.dp),
+                    painter = painterResource(id = R.drawable.ic_arrow_36_left),
                     contentDescription = "Back"
                 )
             }


### PR DESCRIPTION
## 🤘 작업 내용
- 공용 TopBar TopPadding 추가
- 장르/아티스트 구독하기 공용 TopBar 적용
- 구독한 아티스트 빈화면 버튼 클릭 -> 아티스트 구독하기 화면으로 이동
- 아티스트 구독 화면에서 돌아왔을 경우, 구독한 아티스트 업데이트

## 📋 변경된 내용
- 공용 TopBar 수정
- 공용 TopBar 적용이 안되어 있는 발견된곳 적용
- 아티스트 구독 화면에서 돌아왔을 경우, 구독한 아티스트 업데이트

## 💻 동작 화면
- 동작 화면 없음
![Aug-31-2024 10-08-47](https://github.com/user-attachments/assets/cbc6b32c-e0c9-47e1-92dd-f627186c5bcc)

## 📌 비고
- 공용 TopBar 보일러 코드 제거, 컴포넌트로 바꿔야함
