### PR TITLE
예매 오픈 시간 디자인 규격에 맞춰 날짜 표시 형태 변경

### DIFF
--- a/feature/show-detail/src/main/java/com/alreadyoccupiedseat/show_detail/ShowDetailScreen.kt
+++ b/feature/show-detail/src/main/java/com/alreadyoccupiedseat/show_detail/ShowDetailScreen.kt
@@ -47,6 +47,10 @@ import com.alreadyoccupiedseat.designsystem.typo.korean.ShowPotKoreanText_H1
 import com.alreadyoccupiedseat.designsystem.typo.korean.ShowPotKoreanText_H2
 import com.alreadyoccupiedseat.enum.TicketingAlertTime
 import kotlinx.coroutines.flow.collectLatest
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.time.format.TextStyle
+import java.util.Locale
 
 @Composable
 fun ShowDetailScreen(
@@ -297,7 +301,7 @@ fun ShowDetailScreenContent(
                     HorizontalTitleAndInfoText(
                         Modifier.padding(horizontal = 16.dp),
                         "일반예매 오픈",
-                        state.showDetail?.ticketingTimes?.first()?.ticketingAt?.replace("-", ".")
+                        state.showDetail?.ticketingTimes?.first()?.ticketingAt?.formatToReservationDate()
                             ?: String.EMPTY
                     )
                 }
@@ -486,6 +490,18 @@ fun ShowDetailScreenContent(
     }
 }
 
-fun Int.toFormattedString(): String {
+internal fun Int.toFormattedString(): String {
     return "%,d".format(this)
+}
+
+internal fun String.formatToReservationDate(): String {
+    val inputFormatter = DateTimeFormatter.ofPattern("yyyy-M-d HH:mm")
+    val dateTime = LocalDateTime.parse(this, inputFormatter)
+
+    val outputFormatter = DateTimeFormatter.ofPattern("M월 d일 (E) HH:mm")
+
+    val dayOfWeek = dateTime.dayOfWeek
+    val koreanDayOfWeek = dayOfWeek.getDisplayName(TextStyle.FULL, Locale.KOREAN)
+
+    return dateTime.format(outputFormatter).replace(dayOfWeek.name, koreanDayOfWeek)
 }


### PR DESCRIPTION
## 🤘 작업 내용
- 예매 오픈 시간 디자인 규격에 맞춰 날짜 표시 형태 변경

## 📋 변경된 내용
- 예매 오픈 시간 디자인 규격에 맞춰 날짜 표시 형태 변경

## 💻 동작 화면
- 동작 화면 없음

## 📌 비고
- 비고 없음
