### PR TITLE
관심 공연이 없을 경우, 빈화면 전체 공연 보러가기 이벤트 추가 및 연결

### DIFF
--- a/app/src/main/java/com/alreadyoccupiedseat/showpot/ui/AppScreen.kt
+++ b/app/src/main/java/com/alreadyoccupiedseat/showpot/ui/AppScreen.kt
@@ -247,6 +247,9 @@ fun AppScreenContent(
                     navController = navController,
                     onShowClicked = {
                         navController.navigate(Screen.ShowDetail.route.replace("{showId}", it))
+                    },
+                    onEntireShowClicked = {
+                        navController.navigate(Screen.EntireShowList.route)
                     }
                 )
             }

--- a/feature/myfavorite-show/src/main/java/com/alreadyoccupiedseat/myfavorite_show/MyFavoriteShowScreen.kt
+++ b/feature/myfavorite-show/src/main/java/com/alreadyoccupiedseat/myfavorite_show/MyFavoriteShowScreen.kt
@@ -38,7 +38,8 @@ fun MyFavoriteShowScreenPreview(modifier: Modifier = Modifier) {
     val navController = rememberNavController()
     MyFavoriteShowScreen(
         navController = navController,
-        onShowClicked = {}
+        onShowClicked = {},
+        onEntireShowClicked = {}
         )
 }
 
@@ -46,6 +47,7 @@ fun MyFavoriteShowScreenPreview(modifier: Modifier = Modifier) {
 fun MyFavoriteShowScreen(
     navController: NavController,
     onShowClicked: (String) -> Unit,
+    onEntireShowClicked: () -> Unit
 ) {
     val viewModel = hiltViewModel<MyFavoriteShowViewModel>()
     val state = viewModel.state.collectAsState()
@@ -57,6 +59,9 @@ fun MyFavoriteShowScreen(
         },
         onShowClicked = {
             onShowClicked(it)
+        },
+        onEntireShowClicked = {
+            onEntireShowClicked()
         },
         onDeletedMyFavoriteShow = {
             viewModel.deleteMyFavoriteShow(it)
@@ -74,6 +79,7 @@ private fun MyFavoriteShowScreenContent(
     onBackClicked: () -> Unit,
     onShowClicked: (String) -> Unit,
     onDeletedMyFavoriteShow: (showId) -> Unit,
+    onEntireShowClicked: () -> Unit
 ) {
 
     Scaffold(
@@ -90,7 +96,11 @@ private fun MyFavoriteShowScreenContent(
                     .padding(it),
             ) {
                 if (state.interestedShowList.isEmpty()) {
-                    item { MyFavoriteEmpty() }
+                    item { MyFavoriteEmpty(
+                        onEntireShowClicked = {
+                            onEntireShowClicked()
+                        }
+                    ) }
                 } else {
                     itemsIndexed(state.interestedShowList) { index, item ->
                         ShowInfo(
@@ -186,7 +196,9 @@ private fun MyFavoriteShowScreenContent(
 }
 
 @Composable
-fun MyFavoriteEmpty() {
+fun MyFavoriteEmpty(
+    onEntireShowClicked: () -> Unit
+) {
     Column(
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -206,7 +218,7 @@ fun MyFavoriteEmpty() {
             modifier = Modifier.padding(horizontal = 16.dp),
             text = stringResource(id = R.string.action_show_info),
             onClicked = {
-                // TODO 공연 찾기 페이지 이동
+                onEntireShowClicked()
             }
         )
     }

--- a/feature/myfavorite-show/src/main/java/com/alreadyoccupiedseat/myfavorite_show/MyFavoriteShowViewModel.kt
+++ b/feature/myfavorite-show/src/main/java/com/alreadyoccupiedseat/myfavorite_show/MyFavoriteShowViewModel.kt
@@ -3,12 +3,9 @@ package com.alreadyoccupiedseat.myfavorite_show
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.alreadyoccupiedseat.data.show.ShowRepository
-import com.alreadyoccupiedseat.model.Artist
-import com.alreadyoccupiedseat.model.Genre
 import com.alreadyoccupiedseat.model.Show
 import com.alreadyoccupiedseat.model.show.InterestedData
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject


### PR DESCRIPTION
## 🤘 작업 내용
- 관심 공연 없을 경우의 빈 화면 버튼 이벤트 연결 
- 전체 공연으로 화면 이동 