### PR TITLE
검색 화면에서 아티스트 구독 후 아티스트 구독 페이지로 너머가는 기능 추가

### DIFF
--- a/app/src/main/java/com/alreadyoccupiedseat/showpot/ui/AppScreen.kt
+++ b/app/src/main/java/com/alreadyoccupiedseat/showpot/ui/AppScreen.kt
@@ -166,6 +166,9 @@ fun AppScreenContent(
                     onShowClicked = { navController.navigate("showDetail/$it") },
                     onLoginRequested = {
                         navController.navigate(Screen.Login.route)
+                    },
+                    onGoToSeeClicked = {
+                        navController.navigate(Screen.SubscriptionArtist.route)
                     })
             }
 

--- a/feature/search/src/main/java/com/alreadyoccupiedseat/search/SearchScreen.kt
+++ b/feature/search/src/main/java/com/alreadyoccupiedseat/search/SearchScreen.kt
@@ -32,6 +32,7 @@ import androidx.navigation.NavController
 import com.alreadyoccupiedseat.core.extension.EMPTY
 import com.alreadyoccupiedseat.designsystem.ShowpotColor
 import com.alreadyoccupiedseat.designsystem.component.ShowPotSearchBar
+import com.alreadyoccupiedseat.designsystem.component.snackbar.CheckIconSnackbar
 import com.alreadyoccupiedseat.designsystem.component.snackbar.ShowPotSnackbar
 import com.alreadyoccupiedseat.model.SubscribedArtist
 import kotlinx.coroutines.launch
@@ -40,7 +41,8 @@ import kotlinx.coroutines.launch
 fun SearchScreen(
     navController: NavController,
     onLoginRequested: () -> Unit = {},
-    onShowClicked: (String) -> Unit = {}
+    onShowClicked: (String) -> Unit = {},
+    onGoToSeeClicked: () -> Unit = {}
 ) {
 
     val viewModel = hiltViewModel<SearchViewModel>()
@@ -116,6 +118,9 @@ fun SearchScreen(
         },
         onLoginRequested = {
             onLoginRequested()
+        },
+        onGoToSeeClicked = {
+            onGoToSeeClicked()
         }
     )
 }
@@ -137,7 +142,8 @@ fun SearchScreenContent(
     onShowClicked: (String) -> Unit = {},
     onRequestSubscribeArtist: (String) -> Unit = {},
     onRequestUnSubscribeArtist: () -> Unit = {},
-    onLoginRequested: () -> Unit = {}
+    onLoginRequested: () -> Unit = {},
+    onGoToSeeClicked: () -> Unit = {}
 ) {
 
     val focusRequester = remember { FocusRequester() }
@@ -164,14 +170,14 @@ fun SearchScreenContent(
             SnackbarHost(
                 hostState = snackbarHostState,
             ) { snackbarData ->
-                ShowPotSnackbar(
-                    painterResource(id = com.alreadyoccupiedseat.designsystem.R.drawable.ic_check_36),
+                CheckIconSnackbar(
                     mainText = snackbarData.visuals.message,
+                    actionText = "보러가기",
                     onIconClicked = {
                         // onIconClicked()
                     },
                 ) {
-                    // onActionClicked()
+                    onGoToSeeClicked()
                 }
             }
         },

--- a/feature/subscription-artist/src/main/java/com/alreadyoccupiedseat/subscription_artist/SubscriptionArtistScreen.kt
+++ b/feature/subscription-artist/src/main/java/com/alreadyoccupiedseat/subscription_artist/SubscriptionArtistScreen.kt
@@ -15,11 +15,9 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -32,7 +30,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -208,7 +205,6 @@ fun SubscriptionArtistScreenContent(
                     horizontalArrangement = Arrangement.spacedBy(18.dp),
                     verticalArrangement = Arrangement.spacedBy(20.dp)
                 ) {
-                    // TODO: Real Data
 
                     items(state.unsubscribedArtists.size) { index ->
                         val curArtist = state.unsubscribedArtists[index]


### PR DESCRIPTION
## 🤘 작업 내용
- 검색 화면에서 아티스트 구독 후 아티스트 구독 페이지로 너머가는 기능 추가

## 📋 변경된 내용
- 아티스트 구독 후 스낵바에 "보러가기" 텍스트 및 이동 기능 추가

## 💻 동작 화면
- 동작 화면 없음

## 📌 비고
- 비고 없음
