### PR TITLE
공연 상세 페이지에서 티켓팅 알림 예약 조회 실제 Api 연동

### DIFF
--- a/core/network/src/main/java/com/alreadyoccupiedseat/network/ShowService.kt
+++ b/core/network/src/main/java/com/alreadyoccupiedseat/network/ShowService.kt
@@ -56,7 +56,7 @@ interface ShowService {
         @Body alertTimes: TicketingAlertRequest
     ): Response<Unit>
 
-    @POST("api/v1/shows/{showId}/alert/reservations")
+    @GET("api/v1/shows/{showId}/alert/reservations")
     suspend fun checkAlertReservation(
         @Path("showId") showId: String,
         @Query("ticketingApiType") ticketingApiType: String,

--- a/feature/show-detail/src/main/java/com/alreadyoccupiedseat/show_detail/ShowDetailScreen.kt
+++ b/feature/show-detail/src/main/java/com/alreadyoccupiedseat/show_detail/ShowDetailScreen.kt
@@ -91,6 +91,7 @@ fun ShowDetailScreen(
         viewModel.getShowDetail(showId)
         viewModel.registerShowId(showId)
         viewModel.checkLogin()
+        viewModel.checkAlertAvailability()
     }
 
     ShowDetailScreenContent(
@@ -120,11 +121,12 @@ fun ShowDetailScreen(
             viewModel.registerTicketingAlert(
                 showId,
                 "NORMAL",
-                // TODO: request the actual alert times after MVP
-                if (state.value.isThirdItemSelected) {
-                    listOf(TicketingAlertTime.BEFORE_1.name)
-                } else {
-                    emptyList()
+                mutableListOf<String>().apply {
+                    with(state.value) {
+                        if (isFirstItemSelected) this@apply.add(TicketingAlertTime.BEFORE_24.name)
+                        if (isSecondItemSelected) this@apply.add(TicketingAlertTime.BEFORE_6.name)
+                        if (isThirdItemSelected) this@apply.add(TicketingAlertTime.BEFORE_1.name)
+                    }
                 }
             )
         },

--- a/feature/show-detail/src/main/java/com/alreadyoccupiedseat/show_detail/ShowDetailViewModel.kt
+++ b/feature/show-detail/src/main/java/com/alreadyoccupiedseat/show_detail/ShowDetailViewModel.kt
@@ -27,7 +27,7 @@ data class ShowDetailState(
     val isLoginSheetVisible: Boolean = false,
     val isFirstItemAvailable: Boolean = false,
     val isSecondItemAvailable: Boolean = false,
-    val isThirdItemAvailable: Boolean = true,
+    val isThirdItemAvailable: Boolean = false,
     val isFirstItemSelected: Boolean = false,
     val isSecondItemSelected: Boolean = false,
     val isThirdItemSelected: Boolean = false,
@@ -81,7 +81,6 @@ class ShowDetailViewModel @Inject constructor(
             val result =
                 showRepository.registerTicketingAlert(showId, ticketingApiType, alertTimes)
             if (result.isSuccess) {
-//                checkAlertAvailability()
                 _event.emit(ShowDetailEvent.AlertRegisterSuccess)
             } else {
                 println(result.exceptionOrNull())
@@ -119,16 +118,18 @@ class ShowDetailViewModel @Inject constructor(
         }
     }
 
-    // TODO: Bug
-//    private fun checkAlertAvailability() {
-//        viewModelScope.launch {
-//            // TODO: not only for Third Item
-//            val availabilitiesInfo = showRepository.checkAlertReservation(state.value.showId, "NORMAL")
-//            _state.value = _state.value.copy(
-//                isThirdItemSelected = availabilitiesInfo.alertReservationStatus.before1
-//            )
-//        }
-//    }
+    fun checkAlertAvailability() {
+        viewModelScope.launch {
+            val availabilitiesInfo = showRepository.checkAlertReservation(state.value.showId, "NORMAL")
+            _state.value = _state.value.copy(
+                isFirstItemSelected = availabilitiesInfo.alertReservationStatus.before24,
+                isSecondItemSelected = availabilitiesInfo.alertReservationStatus.before6,
+                isThirdItemSelected = availabilitiesInfo.alertReservationStatus.before1,
+                isFirstItemAvailable = availabilitiesInfo.alertReservationAvailability.canReserve24,
+                isSecondItemAvailable = availabilitiesInfo.alertReservationAvailability.canReserve6,
+                isThirdItemAvailable = availabilitiesInfo.alertReservationAvailability.canReserve1
+            )
+        }
+    }
 
-    // TODO: generate fun to change the availability of the first, second, and third item
 }


### PR DESCRIPTION
## 🤘 작업 내용
- 공연 상세 페이지에서 티켓팅 알림 예약 조회 실제 Api 연동

## 📋 변경된 내용
- 공연 상세 페이지에서 티켓팅 알림 예약 조회 실제 Api 연동

## 💻 동작 화면
- 동작 화면 없음

## 📌 비고
- 비고 없음
