### PR TITLE
카카오 로그인 시 유저가 취소했을 때 앱이 크래시나지 않도록 수정

### DIFF
--- a/core/data/src/main/java/com/alreadyoccupiedseat/data/login/LoginRepositoryImpl.kt
+++ b/core/data/src/main/java/com/alreadyoccupiedseat/data/login/LoginRepositoryImpl.kt
@@ -14,8 +14,13 @@ class LoginRepositoryImpl @Inject constructor(
     private val SOCIAL_TYPE_GOOGLE = "GOOGLE"
 
     override suspend fun kakaoLogin(activityContext: Context): Result<Unit> {
-        val kakaoIdentifier = kaKaoLoginDataSource.login(activityContext)
-        return remoteLoginDataSource.login(kakaoIdentifier, SOCIAL_TYPE_KAKAO)
+        return runCatching {
+            kaKaoLoginDataSource.login(activityContext).onSuccess {
+                remoteLoginDataSource.login(it, SOCIAL_TYPE_KAKAO)
+            }.onFailure {
+                throw Exception("카카오 로그인 실패")
+            }
+        }
     }
 
     override suspend fun googleLogin(): Result<Unit> {

--- a/core/data/src/main/java/com/alreadyoccupiedseat/data/login/SocialLoginDataSource.kt
+++ b/core/data/src/main/java/com/alreadyoccupiedseat/data/login/SocialLoginDataSource.kt
@@ -4,6 +4,6 @@ import android.content.Context
 
 interface SocialLoginDataSource {
 
-    suspend fun login(activityContext: Context): String
+    suspend fun login(activityContext: Context): Result<String>
 
 }

--- a/core/data/src/main/java/com/alreadyoccupiedseat/data/login/kakao/KakaoLoginDataSourceImpl.kt
+++ b/core/data/src/main/java/com/alreadyoccupiedseat/data/login/kakao/KakaoLoginDataSourceImpl.kt
@@ -6,25 +6,22 @@ import com.alreadyoccupiedseat.data.login.KakaoLoginDataSource
 import com.alreadyoccupiedseat.data.login.SocialLoginDataSource
 import com.kakao.sdk.auth.model.OAuthToken
 import com.kakao.sdk.user.UserApiClient
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.suspendCancellableCoroutine
 import javax.inject.Inject
 import kotlin.coroutines.resumeWithException
 
 @KakaoLoginDataSource
-class KakaoLoginDataSourceImpl @Inject constructor(
-    @ApplicationContext private val context: Context
-) : SocialLoginDataSource {
+class KakaoLoginDataSourceImpl @Inject constructor() : SocialLoginDataSource {
     @OptIn(ExperimentalCoroutinesApi::class)
-    override suspend fun login(activityContext: Context): String {
+    override suspend fun login(activityContext: Context): Result<String> {
         return suspendCancellableCoroutine { continuation ->
             // 카카오 로그인 콜백
             val callback: (OAuthToken?, Throwable?) -> Unit = { token, error ->
                 if (error != null) {
                     continuation.resumeWithException(Exception(error.message))
                 } else if (token != null) {
-                    continuation.resume(token.idToken ?: String.EMPTY) {
+                    continuation.resume(Result.success(token.idToken ?: String.EMPTY)) {
                         // onCancellation
                     }
                 } else {


### PR DESCRIPTION
## 🤘 작업 내용
- 카카오 로그인 시 유저가 취소했을 때 앱이 크래시나지 않도록 수정

## 📋 변경된 내용
- 변경된 내용을 작성해주세요.

## 💻 동작 화면
- 동작 화면 없음

## 📌 비고
- 비고 없음
