### PR TITLE
토큰 갱신 방법(시점) 변경

### DIFF
--- a/app/src/main/java/com/alreadyoccupiedseat/showpot/MainActivity.kt
+++ b/app/src/main/java/com/alreadyoccupiedseat/showpot/MainActivity.kt
@@ -1,6 +1,5 @@
 package com.alreadyoccupiedseat.showpot
 
-import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
@@ -10,8 +9,12 @@ import android.provider.Settings
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.annotation.RequiresApi
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
 import com.alreadyoccupiedseat.designsystem.ShowPotTheme
 import com.alreadyoccupiedseat.onboarding.OnboardingScreen
 import com.alreadyoccupiedseat.showpot.ui.AppScreen
@@ -35,6 +38,20 @@ class MainActivity : ComponentActivity() {
                 val viewModel = hiltViewModel<MainActivityViewModel>()
                 val state = viewModel.state.collectAsState()
 
+                val lifecycleOwner = LocalLifecycleOwner.current
+                val lifecycleState by lifecycleOwner.lifecycle.currentStateFlow.collectAsState()
+
+                LaunchedEffect(lifecycleState) {
+                    when (lifecycleState) {
+                        Lifecycle.State.DESTROYED -> {}
+                        Lifecycle.State.INITIALIZED -> {}
+                        Lifecycle.State.CREATED -> {}
+                        Lifecycle.State.STARTED -> {}
+                        Lifecycle.State.RESUMED -> {
+                            viewModel.reIssueTokenUseCase()
+                        }
+                    }
+                }
 
                 when (state.value.isOnboardingCompleted) {
 

--- a/app/src/main/java/com/alreadyoccupiedseat/showpot/MainActivityViewModel.kt
+++ b/app/src/main/java/com/alreadyoccupiedseat/showpot/MainActivityViewModel.kt
@@ -26,6 +26,7 @@ data class MainActivityState(
 @HiltViewModel
 class MainActivityViewModel @Inject constructor(
     private val onboardingDataStore: OnboardingDataStore,
+    val reIssueTokenUseCase: ReIssueTokenUseCase
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(MainActivityState())

--- a/core/data/src/main/java/com/alreadyoccupiedseat/data/login/remote/RemoteLoginDataSourceImpl.kt
+++ b/core/data/src/main/java/com/alreadyoccupiedseat/data/login/remote/RemoteLoginDataSourceImpl.kt
@@ -4,7 +4,6 @@ import com.alreadyoccupiedseat.core.extension.EMPTY
 import com.alreadyoccupiedseat.datastore.AccountDataStore
 import com.alreadyoccupiedseat.model.login.LoginRequest
 import com.alreadyoccupiedseat.model.login.ProfileResponse
-import com.alreadyoccupiedseat.model.login.TokenReIssueRequest
 import com.alreadyoccupiedseat.network.LoginService
 import javax.inject.Inject
 
@@ -33,6 +32,8 @@ class RemoteLoginDataSourceImpl @Inject constructor(
 
             val refreshToken = accountDataStore.getRefreshToken()
                 ?: return Result.failure(Exception("Refresh token is null"))
+
+            if (refreshToken.isEmpty()) return Result.failure(Exception("Refresh token is empty"))
 
             val result = loginService.reIssueToken(
                 refreshToken

--- a/core/data/src/main/java/com/alreadyoccupiedseat/data/login/remote/RemoteLoginDataSourceImpl.kt
+++ b/core/data/src/main/java/com/alreadyoccupiedseat/data/login/remote/RemoteLoginDataSourceImpl.kt
@@ -35,12 +35,18 @@ class RemoteLoginDataSourceImpl @Inject constructor(
 
             if (refreshToken.isEmpty()) return Result.failure(Exception("Refresh token is empty"))
 
-            val result = loginService.reIssueToken(
+            val refreshResult = loginService.reIssueToken(
                 refreshToken
-            ).body()
+            )
 
-            accountDataStore.updateAccessToken(result?.accessToken ?: String.EMPTY)
-            accountDataStore.updateRefreshToken(result?.refreshToken ?: String.EMPTY)
+            if (refreshResult.isSuccessful.not()) {
+                return Result.failure(Exception("Refresh token failed on Server"))
+            }
+
+            val result = refreshResult.body() ?: return Result.failure(Exception("Received refresh token body is null"))
+
+            accountDataStore.updateAccessToken(result.accessToken)
+            accountDataStore.updateRefreshToken(result.refreshToken)
         }
     }
 

--- a/core/network/src/main/java/com/alreadyoccupiedseat/network/AuthInterceptor.kt
+++ b/core/network/src/main/java/com/alreadyoccupiedseat/network/AuthInterceptor.kt
@@ -31,6 +31,10 @@ class AuthInterceptor @Inject constructor(
 
     override suspend fun interceptSuspend(chain: Interceptor.Chain): Response {
 
+        if (chain.request().headers["Refresh"] != null) {
+            return chain.proceed(chain.request().newBuilder().build())
+        }
+
         val accessToken = dataStore.getAccessToken()
 
         val token = if (accessToken != null) "Bearer $accessToken"

--- a/core/network/src/main/java/com/alreadyoccupiedseat/network/NetworkModule.kt
+++ b/core/network/src/main/java/com/alreadyoccupiedseat/network/NetworkModule.kt
@@ -32,7 +32,7 @@ class NetworkModule {
                     .writeTimeout(30, TimeUnit.SECONDS)
                     .addInterceptor(
                         HttpLoggingInterceptor().apply {
-                            level = HttpLoggingInterceptor.Level.BODY
+                            level = HttpLoggingInterceptor.Level.BASIC
                         }
                     )
                     .addInterceptor(AuthInterceptor(accessDataStore))

--- a/feature/home/src/main/java/com/alreadyoccupiedseat/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/alreadyoccupiedseat/home/HomeScreen.kt
@@ -64,7 +64,6 @@ fun HomeScreen(
     LaunchedEffect(true) {
         viewModel.getUbSubscribedArtists()
         viewModel.getNickName()
-        viewModel.refreshTokens()
     }
 
     HomeScreenContent(

--- a/feature/home/src/main/java/com/alreadyoccupiedseat/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/alreadyoccupiedseat/home/HomeViewModel.kt
@@ -127,12 +127,4 @@ class HomeViewModel@Inject constructor(
         }
     }
 
-    fun refreshTokens() {
-        viewModelScope.launch {
-            accountDataStore.getRefreshToken()?.let {
-                loginRepository.reIssueToken()
-            }
-        }
-    }
-
 }

--- a/feature/onboarding/src/main/java/com/alreadyoccupiedseat/onboarding/OnboardingViewModel.kt
+++ b/feature/onboarding/src/main/java/com/alreadyoccupiedseat/onboarding/OnboardingViewModel.kt
@@ -18,15 +18,15 @@ class OnboardingViewModel @Inject constructor(
     private val onboardingDataStore: OnboardingDataStore
 ) : ViewModel() {
 
+    private var _event = MutableSharedFlow<OnboardingScreenEvent>()
+    val event = _event
+
     init {
         viewModelScope.launch {
             val isOnboardingFinished = isOnboardingFinished()
             _event.emit(if (isOnboardingFinished) OnboardingScreenEvent.OnboardingCompleted else OnboardingScreenEvent.Idle)
         }
     }
-
-    private var _event = MutableSharedFlow<OnboardingScreenEvent>()
-    val event = _event
 
     fun completeOnboarding() {
         viewModelScope.launch {


### PR DESCRIPTION
## 🤘 작업 내용
- 리프래시 토큰이 공백일 경우 발생했던 문제 해결
- 토큰 갱신을 생명주기 Resume에서 하도록 변경
- 앱 최초 실행 시 온보딩 이벤트에서 발생했던 이슈 해결

## 📋 변경된 내용
- HTTP 로깅 수준 변경

## 💻 동작 화면
- 동작 화면 없음

## 📌 비고
- 비고 없음
